### PR TITLE
Add initial structure and button component

### DIFF
--- a/src/Button/Button.scss
+++ b/src/Button/Button.scss
@@ -1,4 +1,0 @@
-.Button {
-  color: white;
-  background-color: #7fc243;
-}

--- a/src/base/config.scss
+++ b/src/base/config.scss
@@ -1,0 +1,116 @@
+/**
+ * State Color Settings
+ *
+ * These should stay consistent across themes
+ */
+
+$color-success:        #7fc243 !default;
+$color-success--light: lighten($color-success, 45%) !default;
+$color-success--dark:  darken($color-success, 7.5%) !default;
+$color-success--bg:    lighten($color-success, 45%) !default;
+
+$color-danger:         #e26362 !default;
+$color-danger--light:  lighten($color-danger, 30%) !default;
+$color-danger--dark:   darken($color-danger, 7.5%) !default;
+$color-danger--bg:     lighten($color-danger, 30%) !default;
+
+$color-warning:        #ff8f00 !default;
+$color-warning--light: #ff8f00 !default;
+$color-warning--dark:  #ff8f00 !default;
+$color-warning--bg:    #fdf7ef !default;
+
+$color-info:           #494949 !default;
+$color-info--light:    #797979 !default;
+$color-info--dark:     #292929 !default;
+
+/**
+ * Brand Colors
+ *
+ * These can change for different themes
+ */
+
+$color-primary:          #1667AC !default;
+$color-primary--light:   #0279CE !default;
+$color-primary--dark:    darken($color-primary, 5%) !default;
+$color-primary--muted:   #45647f !default;
+$color-primary--bg:      #e7eef8 !default;
+
+$color-secondary:        #1667AC !default;
+$color-secondary--light: #469eea !default;
+$color-secondary--dark:  #1667AC !default;
+$color-secondary--muted: #45647f !default;
+$color-secondary--bg:    #e7edf4 !default;
+
+$color-highlight:        $color-success !default;
+$color-highlight--light: $color-success--light !default;
+$color-highlight--dark:  $color-success--dark !default;
+
+$color-user-highlight:   rgba($color-primary--light, .02) !default;
+
+/**
+ * UI Colors
+ */
+
+$ui-foreground:          #ffffff !default;
+$ui-foreground--light:   #ffffff !default;
+$ui-foreground--dark:    #ffffff !default;
+
+$ui-middleground:        #fcfcfc !default;
+$ui-middleground--light: #fefefe !default;
+$ui-middleground--dark:  #f8f8f8 !default;
+
+$ui-background:          #f4f4f4 !default;
+$ui-background--light:   #f4f4f4 !default;
+$ui-background--dark:    #f4f4f4 !default;
+
+$ui-divider:             #d6d6d6 !default;
+$ui-divider--light:      #e6e6e6 !default;
+$ui-divider--dark:       #d6d6d6 !default;
+
+$ui-highlight:           #fcfcfc !default;
+$ui-highlight--light:    #fefefe !default;
+$ui-highlight--dark:     #f8f8f8 !default;
+
+$ui-white:               #fff !default;
+$ui-grey:                #999 !default;
+$ui-black:               #333 !default;
+
+
+/**
+ * Transitions
+ */
+
+$duration-short: 250ms;
+
+
+/**
+ * Borders
+ */
+
+$border-radius-small:  3px !default;
+$border-radius-medium: 5px !default;
+$border-radius-large:  8px !default;
+
+$border-width-small:   1px;
+$border-width-medium:  2px;
+
+
+/**
+ * Typography
+ */
+
+ $open-sans:  'Open Sans', Helvetica, sans-serif !default;
+
+ $base-font-family:  $open-sans !default;
+ $base-font-size:    13px !default;
+ $small-font-size:   round($base-font-size * 0.9) !default;
+
+ $base-font-color:   $color-info !default;
+ $light-font-color:  $color-info--light !default;
+
+ $base-line-height:  1.4 !default;
+ $tight-line-height: 1.15 !default;
+
+ $base-font-weight:  normal !default;
+ $med-font-weight:   600 !default;
+ $bold-font-weight:  bolder !default;

--- a/src/base/fonts/index.scss
+++ b/src/base/fonts/index.scss
@@ -1,0 +1,1 @@
+@import "open-sans";

--- a/src/base/fonts/open-sans.scss
+++ b/src/base/fonts/open-sans.scss
@@ -1,0 +1,128 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/K88pR3goAWT7BTt32Z01mxJtnKITppOI_IvcXXDNrsc.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/RjgO7rYTmqiVp7vzi-Q5URJtnKITppOI_IvcXXDNrsc.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/LWCjsQkB6EMdfHrEVqA1KRJtnKITppOI_IvcXXDNrsc.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/xozscpT2726on7jbcb_pAhJtnKITppOI_IvcXXDNrsc.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/59ZRklaO5bWGqF5A9baEERJtnKITppOI_IvcXXDNrsc.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/u-WUoqrET9fUeobQW7jkRRJtnKITppOI_IvcXXDNrsc.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/cJZKeOuBrn4kERxqtaUH3VtXRa8TVwTICgirnJhmVJw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSj0LW-43aMEzIO6XUTLjad8.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSugdm0LZdjqr5-oayXSOefg.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzK-j2U0lmluP9RWlSytm3ho.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzJX5f-9o1vgP2EXwfjgl7AY.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzBWV49_lSm1NYrwo-zkhivY.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzKaRobkAwv3vxw3jMhVENGA.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzP8zf_FOSsgRmwsS7Aa9k2w.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzD0LW-43aMEzIO6XUTLjad8.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzOgdm0LZdjqr5-oayXSOefg.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/src/base/index.scss
+++ b/src/base/index.scss
@@ -1,0 +1,3 @@
+@import "fonts/index";
+@import "config";
+@import "typography";

--- a/src/base/typography.scss
+++ b/src/base/typography.scss
@@ -1,0 +1,3 @@
+body {
+  font-family: 'Open Sans', Helvetica, sans-serif;
+}

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -70,10 +70,10 @@ $Button-padding: 0 ($Button-height / 1.75);
  * Modifier: Button Primary
  */
 
-$Button--primary-bg: $color-primary;
+$Button--primary-bg: $color-highlight;
 $Button--primary-bg-hover: darken($Button--primary-bg, 5%);
 $Button--primary-color: $ui-white;
-$Button--primary-border-color: darken($Button--primary-bg, 7.5%);
+$Button--primary-border-color: $color-highlight--dark;
 $Button--primary-border-color-hover: darken($Button--primary-bg, 10%);
 
 .Button--primary {
@@ -100,44 +100,6 @@ $Button--primary-border-color-hover: darken($Button--primary-bg, 10%);
     &:active {
       background-color: $Button--primary-bg;
       border-color: $Button--primary-border-color;
-    }
-  }
-}
-
-/**
- * Modifier: Button Positive
- */
-
-$Button--positive-bg: $color-highlight;
-$Button--positive-bg-hover: darken($Button--positive-bg, 5%);
-$Button--positive-color: $ui-white;
-$Button--positive-border-color: $color-highlight--dark;
-$Button--positive-border-color-hover: darken($Button--positive-bg, 10%);
-
-.Button--positive {
-  background-color: $Button--positive-bg;
-  border-color: $Button--positive-border-color;
-  color: $Button--positive-color;
-
-  &:hover,
-  &:active,
-  &:focus {
-    background-color: $Button--positive-bg-hover;
-    border-color: $Button--positive-border-color-hover;
-  }
-
-  &.is-active {
-    background-color: $Button--positive-bg-hover;
-    box-shadow: 0 1px 0 $Button--positive-border-color inset;
-  }
-
-  &.is-disabled,
-  &:disabled {
-    &,
-    &:hover,
-    &:active {
-      background-color: $Button--positive-bg;
-      border-color: $Button--positive-border-color;
     }
   }
 }

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -1,3 +1,5 @@
+@import "./base/config";
+
 /**
  * @define default Button
  */
@@ -30,7 +32,7 @@ $Button-padding: 0 ($Button-height / 1.75);
   font-size: $Button-font-size;
   font-weight: $Button-font-weight;
   height: $Button-height;
-  line-height: normal;
+  line-height: $Button-line-height;
   margin: 0;
   padding: $Button-padding;
   text-decoration: none;

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -1,0 +1,217 @@
+/**
+ * @define default Button
+ */
+
+$Button-bg: $ui-white;
+$Button-bg-hover: $ui-background;
+$Button-color: $color-info;
+$Button-border-color: $ui-divider;
+$Button-border-color-hover: darken($Button-border-color, 10%);
+$Button-border-radius: $border-radius-medium;
+$Button-border-width: $border-width-small;
+$Button-border-bottom-width: $border-width-medium;
+$Button-disabled-opacity: 0.4;
+$Button-font-family: $base-font-family;
+$Button-font-size: $base-font-size;
+$Button-font-weight: $med-font-weight;
+$Button-height: 34px;
+$Button-line-height: $Button-height - 2;
+$Button-padding: 0 ($Button-height / 1.75);
+
+.Button {
+  background-color: $Button-bg;
+  border: $Button-border-color solid $Button-border-width;
+  border-bottom-width: $Button-border-bottom-width;
+  border-radius: $Button-border-radius;
+  color: $Button-color;
+  cursor: pointer;
+  display: inline-block;
+  font-family: $Button-font-family;
+  font-size: $Button-font-size;
+  font-weight: $Button-font-weight;
+  height: $Button-height;
+  line-height: normal;
+  margin: 0;
+  padding: $Button-padding;
+  text-decoration: none;
+  transition: all $duration-short ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: $Button-bg-hover;
+    border-color: $Button-border-color-hover;
+    outline: none;
+  }
+
+  &.is-active {
+    background-color: $Button-bg-hover;
+    box-shadow: 0 1px 0 $Button-border-color inset;
+  }
+
+  &.is-disabled,
+  &:disabled {
+    &,
+    &:hover,
+    &:active {
+      background-color: $Button-bg;
+      border-color: $Button-border-color;
+      cursor: not-allowed;
+      opacity: $Button-disabled-opacity;
+    }
+  }
+}
+
+/**
+ * Modifier: Button Primary
+ */
+
+$Button--primary-bg: $color-primary;
+$Button--primary-bg-hover: darken($Button--primary-bg, 5%);
+$Button--primary-color: $ui-white;
+$Button--primary-border-color: darken($Button--primary-bg, 7.5%);
+$Button--primary-border-color-hover: darken($Button--primary-bg, 10%);
+
+.Button--primary {
+  background-color: $Button--primary-bg;
+  border-color: $Button--primary-border-color;
+  color: $Button--primary-color;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: $Button--primary-bg-hover;
+    border-color: $Button--primary-border-color-hover;
+  }
+
+  &.is-active {
+    background-color: $Button--primary-bg-hover;
+    box-shadow: 0 1px 0 $Button--primary-border-color inset;
+  }
+
+  &.is-disabled,
+  &:disabled {
+    &,
+    &:hover,
+    &:active {
+      background-color: $Button--primary-bg;
+      border-color: $Button--primary-border-color;
+    }
+  }
+}
+
+/**
+ * Modifier: Button Positive
+ */
+
+$Button--positive-bg: $color-highlight;
+$Button--positive-bg-hover: darken($Button--positive-bg, 5%);
+$Button--positive-color: $ui-white;
+$Button--positive-border-color: $color-highlight--dark;
+$Button--positive-border-color-hover: darken($Button--positive-bg, 10%);
+
+.Button--positive {
+  background-color: $Button--positive-bg;
+  border-color: $Button--positive-border-color;
+  color: $Button--positive-color;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: $Button--positive-bg-hover;
+    border-color: $Button--positive-border-color-hover;
+  }
+
+  &.is-active {
+    background-color: $Button--positive-bg-hover;
+    box-shadow: 0 1px 0 $Button--positive-border-color inset;
+  }
+
+  &.is-disabled,
+  &:disabled {
+    &,
+    &:hover,
+    &:active {
+      background-color: $Button--positive-bg;
+      border-color: $Button--positive-border-color;
+    }
+  }
+}
+
+/**
+ * Modifier: Button Negative
+ */
+
+$Button--negative-bg: $ui-white;
+$Button--negative-bg-hover: $color-danger;
+$Button--negative-color: $color-danger;
+$Button--negative-color-hover: $ui-white;
+$Button--negative-border-color: $ui-divider;
+$Button--negative-border-color-hover: $color-danger--dark;
+
+.Button--negative {
+  background-color: $Button--negative-bg;
+  border-color: $Button--negative-border-color;
+  color: $Button--negative-color;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: $Button--negative-bg-hover;
+    border-color: $Button--negative-border-color-hover;
+    color: $Button--negative-color-hover;
+  }
+
+  &.is-active {
+    background-color: $Button--negative-bg-hover;
+    border-color: $Button--negative-border-color-hover;
+    box-shadow: 0 1px 0 $Button--negative-border-color-hover inset;
+    color: $Button--negative-color-hover;
+  }
+
+  &.is-disabled,
+  &:disabled {
+    &,
+    &:hover,
+    &:active {
+      background-color: $Button--negative-bg;
+      border-color: $Button--negative-border-color;
+      color: $Button--negative-color;
+    }
+  }
+}
+
+/**
+ * Modifier: Button Small
+ */
+
+$Button--small-font-size: $small-font-size;
+$Button--small-height: 22px;
+$Button--small-line-height: $Button--small-height - 2;
+$Button--small-padding: 0 ($Button--small-height * 0.5);
+
+
+.Button--small {
+  font-size: $Button--small-font-size;
+  height: $Button--small-height;
+  line-height: $Button--small-line-height;
+  padding: $Button--small-padding;
+}
+
+/**
+ * Modifier: Button Large
+ */
+
+$Button--large-font-size: $base-font-size * 1.1;
+$Button--large-height: 46px;
+$Button--large-line-height: $Button--large-height - 2;
+$Button--large-padding: 0 ($Button--large-height / 1.5);
+
+.Button--large {
+  font-size: $Button--large-font-size;
+  height: $Button--large-height;
+  line-height: $Button--large-line-height;
+  padding: $Button--large-padding;
+}

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -1,0 +1,1 @@
+@import "button";

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,0 +1,2 @@
+@import "base/index";
+@import "components/index";


### PR DESCRIPTION
This PR adds a directory structure seeded with some of the initial settings for defining components. The variables in `config` are pulled from Classic since all the themes are based on these names. The Button component kicks off a new [BEM naming convention](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md).

I tried out including the variable `config.scss` in the `.Button` component. Let's see how that works out. We can modify if that doesn't seem right.

Some of the structure is built to facilitate the inclusion of this library as a submodule within the style guide. For example, adding `index`es within each directory and in the top level makes it easy to grab just one file for compilation in the style guide:

![button](https://cloud.githubusercontent.com/assets/9888467/26117584/e4a2c02e-3a1b-11e7-9624-4177f1e29c12.png)

