### PR TITLE
fixes issue with comment breaking compile

### DIFF
--- a/src/base/config.scss
+++ b/src/base/config.scss
@@ -1,6 +1,7 @@
-// TODO : Revisit spacing scale and look to simplify around an 8px grid
-// TODO : Revisit typographic scale to find common ground with marketing
-// TODO : take audit of the museo fonts used and clean up heading font variables
+
+// TODO Revisit spacing scale and look to simplify around an 8px grid
+// TODO Revisit typographic scale to find common ground with marketing
+// TODO take audit of the museo fonts used and clean up heading font variables
 
 /**
  * State Color Settings


### PR DESCRIPTION
For some reason webpack picks up colons in sass comments and fails due to a missing semicolon. 