### PR TITLE
Add grey color utility and negative margin utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "scripts": {

--- a/src/css/utils/color.scss
+++ b/src/css/utils/color.scss
@@ -18,6 +18,15 @@
   color: $cu-info !important;
 }
 
+.u-colorGrey {
+  color: $ts-grey !important;
+}
+
+.u-colorHighlight {
+  color: $cu-highlight !important;
+}
+
+
 // * Link Colors (other than default)
 
 .u-linkNegative {

--- a/src/css/utils/space.scss
+++ b/src/css/utils/space.scss
@@ -73,6 +73,8 @@ $spaces: (
   }
 }
 
+// * Responsive utilities
+
 @if $responsive == true {
   @each $bp-name, $bp-value in $breakpoints {
     @media (min-width: $bp-value) {
@@ -120,4 +122,12 @@ $spaces: (
       }
     }
   }
+}
+
+// * Negative margin Utilities
+//
+//   Add more as necessary
+
+.u-spaceNegativeRightSm {
+  margin-right: -1 * $su-small !important;
 }


### PR DESCRIPTION
Adds utilities to support table header controls:
- grey color utility for $ts-grey @williamdingwall foreground/background/middleground were all too light or too dark. $ts-grey gets themed, right?
- negative margin utility for right-aligned sorting arrows
- Examples in UI-Patterns PR: https://github.com/teamsnap/ui-patterns/pull/45