### PR TITLE
Add popup component and status buttons

### DIFF
--- a/src/css/components/Button.scss
+++ b/src/css/components/Button.scss
@@ -1,8 +1,6 @@
 @import "../config/index.scss";
 
-/**
- * @define default Button
- */
+// * @define default Button
 
 $Button-bg: $ts-white;
 $Button-bg-hover: $cu-background;
@@ -67,9 +65,8 @@ $Button-padding: 0 scaleGrid(2);
   }
 }
 
-/**
- * Modifier: Button Primary
- */
+
+// * Modifier: Button Primary
 
 $Button--primary-bg: $cu-secondary;
 $Button--primary-bg-hover: scaleColor($Button--primary-bg, -1);
@@ -107,9 +104,8 @@ $Button--primary-border-color-hover: scaleColor($cu-secondary--dark, -1);
   }
 }
 
-/**
- * Modifier: Button Negative
- */
+
+// * Modifier: Button Negative
 
 $Button--negative-bg: $ts-white;
 $Button--negative-bg-hover: $cu-negative;
@@ -149,9 +145,8 @@ $Button--negative-border-color-hover: $cu-negative--dark;
   }
 }
 
-/**
- * Modifier: Button Small
- */
+// * Modifier: Button Small
+
 
 $Button--small-font-size: $tu-small-fontSize;
 $Button--small-height: scaleGrid(3);
@@ -166,9 +161,17 @@ $Button--small-padding: 0 $su-small;
   padding: $Button--small-padding;
 }
 
-/**
- * Modifier: Button Large
- */
+// * Modifier: Button Square small
+
+.Button--smallSquare {
+  width: $Button--small-height;
+  height: $Button--small-height;
+  line-height: $Button--small-line-height;
+  padding: 0;
+}
+
+
+// * Modifier: Button Large
 
 $Button--large-font-size: $tu-base-fontSize;
 $Button--large-height: scaleGrid(5);
@@ -180,4 +183,61 @@ $Button--large-padding: 0 scaleGrid(3);
   height: $Button--large-height;
   line-height: $Button--large-line-height;
   padding: $Button--large-padding;
+}
+
+
+// * Modifier: Yes / Maybe / No modifiers for setting status
+//
+//   --yesDefault, --noDefault, and --maybeDefault start with the default white button,
+//   and hover and active states have yes / maybe / no colors
+//
+//   --yes, --no, and --maybe always have yes / maybe / no colors
+
+
+.Button--yesDefault.is-active,
+.Button--yesDefault:hover,
+.Button--yes {
+  background-color: $cu-positive;
+  color: $ts-white;
+  border-color: scaleColor($cu-positive, -1);
+}
+
+.Button--yes {
+  &:hover, &:active, &:focus, &.is-active {
+    background-color: scaleColor($cu-positive, -1);
+    color: $ts-white;
+    border-color: scaleColor($cu-positive, -2);
+  }
+}
+
+.Button--maybeDefault.is-active,
+.Button--maybeDefault:hover,
+.Button--maybe {
+  background-color: $ts-darkblue;
+  color: $ts-white;
+  border-color: scaleColor($ts-darkblue, -1);
+}
+
+.Button--maybe {
+  &:hover, &:active, &:focus, &.is-active {
+    background-color: scaleColor($ts-darkblue, -1);
+    color: $ts-white;
+    border-color: scaleColor($ts-darkblue, -2);
+  }
+}
+
+.Button--noDefault.is-active,
+.Button--noDefault:hover,
+.Button--no {
+  background-color: $cu-negative;
+  color: $ts-white;
+  border-color: scaleColor($cu-negative, -1);
+}
+
+.Button--no {
+  &:hover, &:active, &:focus, &.is-active {
+    background-color: scaleColor($cu-negative, -1);
+    color: $ts-white;
+    border-color: scaleColor($cu-negative, -2);
+  }
 }

--- a/src/css/components/ButtonGroup.scss
+++ b/src/css/components/ButtonGroup.scss
@@ -18,8 +18,11 @@ $ButtonGroup-space: -1 * $border-width-small;
 // * 1. Overlap elements and override any vertical margins.
 // * 2. Reset `border-radius` so corners line up.
 
+.ButtonGroup > .Button + .Button {
+  margin-left: $ButtonGroup-space; // 1
+}
+
 .ButtonGroup > .Button {
-  margin: 0 $ButtonGroup-space; // 1
   border-radius: 0; // 2
 }
 

--- a/src/css/components/Popup.scss
+++ b/src/css/components/Popup.scss
@@ -1,0 +1,207 @@
+$Popup-offset: 10px;
+$Popup-arrow-size: 12px;
+$Popup-arrow-offset: $Popup-arrow-size / 2;
+$Popup-arrow-offsetCover: ($Popup-arrow-size / 2) + 1;
+$Popup-arrow-borderRadius: 3px;
+
+// * .Popup
+// * Wrapper for the popup elements. Display inline-block so it assumes the
+// * size of the nested triggering element.
+
+.Popup {
+  position: relative;
+  display: inline-block;
+}
+
+// * .Popup-toggle
+// * The triggering element. No styles, but exists as an identifying class.
+
+.Popup-toggle {
+}
+
+// * .Popup-container
+// * Sets the position of the popup relative to the toggle
+//
+// * 1. The bottom of the popup is positioned at the _top_ of the trigger, plus some space
+// * 2. Centers the element over the trigger
+// * 3. Positions popup above other elements on the page
+//   TODO: This might need adjusted depending on relative stacking index
+//   TODO: Create relative stacking index variables so that orders can be organized
+// * 4. Set a default width. This can be changed inline as necessary.
+// * 5. Hide until it is triggered.
+
+.Popup-container {
+  position: absolute; // 1
+  bottom: calc(100% + #{$Popup-offset}); // 1
+  left: 50%; // 2
+  transform: translateX(-50%); // 2
+  z-index: 100; // 3
+  width: 250px; // 4
+  display: none; // 5
+}
+
+.Popup-container.is-open {
+  display: block;
+}
+
+// * .Popup-arrow
+// * Arrow that points to triggering element
+//
+// * Sandwiches and centers two squares, rotated 45°, around .Popup-content
+
+.Popup-container::before,
+.Popup-container::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: $Popup-arrow-size;
+	height: $Popup-arrow-size;
+  background-color: $ts-white;
+  border-radius: $Popup-arrow-borderRadius 0 $Popup-arrow-borderRadius 0;
+  animation: popInArrow 75ms cubic-bezier(0.2, 0.8, 0.4, 1.0) forwards;
+}
+
+// * Bottom square has border and box shadow
+
+.Popup-container::before {
+  top: calc( 100% - #{$Popup-arrow-offset} );
+  border: solid $ts-grey $border-width-small;
+  box-shadow: $box-shadow-small;
+}
+
+// * Top square is white and conceals the top half of the border/shadow styles
+//   of bottom square that overlay the popup
+
+.Popup-container::after {
+  top: calc( 100% - #{$Popup-arrow-offsetCover} );
+}
+
+// * .Popup-content
+// * The popup box
+
+.Popup-content {
+  background-color: $ts-white;
+  border: solid $ts-grey $border-width-small;
+  border-radius: $border-radius-medium;
+  box-shadow: $box-shadow-small;
+  animation: popIn 75ms cubic-bezier(0.2, 0.8, 0.4, 1.0) forwards;
+}
+
+// * Overlay modifier
+//
+// * Positions popover directly on top of toggle, centered vertically and horizontally
+// * Removes arrow pointer
+
+.Popup-container--overlay {
+  bottom: 50%;
+  transform: translateX(-50%) translateY(50%);
+
+  &::before,
+  &::after {
+    display: none;
+  }
+}
+
+// * Down modifier
+//
+// * Positions popover below content
+// * Respositions arrow pointer
+
+.Popup-container--down {
+  bottom: auto;
+  top: calc(100% + #{$Popup-offset});
+  &::before {
+    top: -1 * $Popup-arrow-offset;
+  }
+  &::after {
+    top: -1 * ($Popup-arrow-offset - 1);
+  }
+}
+
+// * Left modifier
+//
+// * Aligns popover with left side of toggle
+
+.Popup-container--left {
+  left: 0;
+  transform: none;
+
+  &::before,
+  &::after {
+    left: $su-large;
+    transform: translateX(0) rotate(45deg);
+  }
+}
+
+// * Left Hanging modifier
+//
+// * Aligns popover so that it "hangs" off the left side of the toggle
+
+.Popup-container--leftHang {
+  left: -1 * $su-large;
+  transform: none;
+
+  &::before,
+  &::after {
+    left: $su-large + $su-small;
+    transform: translateX(0) rotate(45deg);
+  }
+}
+
+
+// * Right modifier
+//
+// * Aligns popover with right side of toggle
+
+.Popup-container--right {
+  left: auto;
+  right: 0;
+  transform: none;
+
+  &::before,
+  &::after {
+    left: auto;
+    right: $su-large;
+    transform: translateX(0) rotate(45deg);
+  }
+}
+
+// * Right Hanging modifier
+//
+// * Aligns popover so that it "hangs" off the right side of the toggle
+
+.Popup-container--rightHang {
+  left: auto;
+  right: -1 * $su-large;
+  transform: none;
+
+  &::before,
+  &::after {
+    left: auto;
+    right: $su-large + $su-small;
+    transform: translateX(0) rotate(45deg);
+  }
+}
+
+// * Animations
+
+@keyframes popIn {
+  0% {
+    opacity: 0;
+    transform: scale3d(0.7, 0.7, 0.7);
+  }
+  100% {
+    opacity: 1;
+    transform: scale3d(1.0, 1.0, 1.0);
+  }
+}
+
+@keyframes popInArrow {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/src/css/components/index.scss
+++ b/src/css/components/index.scss
@@ -7,6 +7,7 @@
 @import "InputGroup";
 @import "Toggle";
 @import "Input";
+@import "Popup";
 @import "SelectBox";
 @import "StepNav";
 @import "Panel";


### PR DESCRIPTION
# Adds `Popup` component and some button modifiers.

## `Popup`
Includes modifiers for several popup positions:
- Default - up and centered
![popup-default](https://user-images.githubusercontent.com/9888467/38506256-f24c3064-3bde-11e8-8d5c-a86fc336779a.gif)

- Overlay - on top of the triggering element, no pointer
![popup-overlay](https://user-images.githubusercontent.com/9888467/38506262-f72e6b1a-3bde-11e8-8ba4-b70f21d3b069.gif)

- Down - below the triggering element, centered by default
![popup-down](https://user-images.githubusercontent.com/9888467/38506271-fdc5b2e4-3bde-11e8-8fc5-0220ad1668c6.gif)

- Right - right-aligned with triggering element (can be combined with down modifier)
![popup-right](https://user-images.githubusercontent.com/9888467/38506282-013f5d4e-3bdf-11e8-9f52-2ae8c7fbcb4e.gif)

- Right Hang - hangs off the right side of an element. Useful for small buttons or icon buttons.
![popup-right-hang](https://user-images.githubusercontent.com/9888467/38506295-07c7a608-3bdf-11e8-9a4b-c0d4307ee22a.gif)

- Left - left-aligned with triggering element (can be combined with down modifier)
![popup-left](https://user-images.githubusercontent.com/9888467/38506290-04a7fd4c-3bdf-11e8-9ca7-6b5c18ff51c2.gif)


- Left Hang - hangs off the left side of an element. Useful for small buttons or icon buttons.
![popup-left-hang](https://user-images.githubusercontent.com/9888467/38506302-0b800024-3bdf-11e8-8e07-dd79f140ab3b.gif)

# Status buttons

Two options for status buttons.

1. Button is neutral by default, and when hovered or `is-active` (as in ButtonGroup), it gets yes/no/maybe color

![button-status-1](https://user-images.githubusercontent.com/9888467/38506445-86223284-3bdf-11e8-9c43-ffadceb12216.gif)

2. Button has yes/no/maybe color by default
![button-status-2](https://user-images.githubusercontent.com/9888467/38506451-88a594b0-3bdf-11e8-94f3-53416eff8b7e.gif)

# Small square button

Button intended for symbols or icons, has fixed width and height equal to height of `Button--small`.

<img width="1127" alt="screen shot 2018-04-09 at 9 59 43 am" src="https://user-images.githubusercontent.com/9888467/38506524-bcdb8d52-3bdf-11e8-81e6-a2db2cbb2fc2.png">

