### PR TITLE
Add textarea to is-notValid style class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "scripts": {

--- a/src/css/components/FieldGroup.scss
+++ b/src/css/components/FieldGroup.scss
@@ -50,7 +50,7 @@ $FieldGroup-font-size: $tu-base-fontSize;
 // * 3. Form Group States
 
 .FieldGroup.is-notValid {
-  .Input, .Checkbox-label:before, .SelectBox-options {
+  .Input, .Checkbox-label:before, .SelectBox-options, textarea {
     border-color: $cu-negative;
   }
 }


### PR DESCRIPTION
When need to have the red border when validating textarea.

![image](https://user-images.githubusercontent.com/8335640/39958770-370e7fe2-55cd-11e8-9081-d6956e966a96.png)
