### PR TITLE
Update font paths to use an absolute path to CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "scripts": {

--- a/src/css/fonts/museo.scss
+++ b/src/css/fonts/museo.scss
@@ -6,60 +6,60 @@
 
 @font-face {
   font-family: 'MuseoSansRounded100Regular';
-  src: url('/assets/fonts/museo/MuseoSansRounded-100-webfont.eot');
-  src: url('/assets/fonts/museo/MuseoSansRounded-100-webfont.woff') format('woff'),
-    url('/assets/fonts/museo/MuseoSansRounded-100-webfont.ttf') format('truetype'),
-    url('/assets/fonts/museo/MuseoSansRounded-100-webfont.svg') format('svg');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.eot');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.woff') format('woff'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.ttf') format('truetype'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded300Regular';
-  src: url('/assets/fonts/museo/MuseoSansRounded-300-webfont.eot');
-  src: url('/assets/fonts/museo/MuseoSansRounded-300-webfont.woff') format('woff'),
-    url('/assets/fonts/museo/MuseoSansRounded-300-webfont.ttf') format('truetype'),
-    url('/assets/fonts/museo/MuseoSansRounded-300-webfont.svg') format('svg');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.eot');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.woff') format('woff'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.ttf') format('truetype'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded500Regular';
-  src: url('/assets/fonts/museo/MuseoSansRounded-500-webfont.eot');
-  src: url('/assets/fonts/museo/MuseoSansRounded-500-webfont.woff') format('woff'),
-    url('/assets/fonts/museo/MuseoSansRounded-500-webfont.ttf') format('truetype'),
-    url('/assets/fonts/museo/MuseoSansRounded-500-webfont.svg') format('svg');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.eot');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.woff') format('woff'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.ttf') format('truetype'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded700Regular';
-  src: url('/assets/fonts/museo/MuseoSansRounded-700-webfont.eot');
-  src: url('/assets/fonts/museo/MuseoSansRounded-700-webfont.woff') format('woff'),
-    url('/assets/fonts/museo/MuseoSansRounded-700-webfont.ttf') format('truetype'),
-    url('/assets/fonts/museo/MuseoSansRounded-700-webfont.svg') format('svg');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.eot');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.woff') format('woff'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.ttf') format('truetype'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded900Regular';
-  src: url('/assets/fonts/museo/MuseoSansRounded-900-webfont.eot');
-  src: url('/assets/fonts/museo/MuseoSansRounded-900-webfont.woff') format('woff'),
-    url('/assets/fonts/museo/MuseoSansRounded-900-webfont.ttf') format('truetype'),
-    url('/assets/fonts/museo/MuseoSansRounded-900-webfont.svg') format('svg');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.eot');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.woff') format('woff'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.ttf') format('truetype'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded1000Regular';
-  src: url('/assets/fonts/museo/MuseoSansRounded-1000-webfont.eot');
-  src: url('/assets/fonts/museo/MuseoSansRounded-1000-webfont.woff') format('woff'),
-    url('/assets/fonts/museo/MuseoSansRounded-1000-webfont.ttf') format('truetype'),
-    url('/assets/fonts/museo/MuseoSansRounded-1000-webfont.svg') format('svg');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.eot');
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.woff') format('woff'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.ttf') format('truetype'),
+    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/css/fonts/ss-pika.scss
+++ b/src/css/fonts/ss-pika.scss
@@ -15,10 +15,10 @@
 
 @font-face {
   font-family: "SSPika";
-  src: url('/assets/fonts/ss-pika/ss-pika.eot'),
-       url('/assets/fonts/ss-pika/ss-pika.woff') format("woff"),
-       url('/assets/fonts/ss-pika/ss-pika.ttf') format("truetype"),
-       url('/assets/fonts/ss-pika/ss-pika.svg') format("svg");
+  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.eot'),
+       url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.woff') format("woff"),
+       url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.ttf') format("truetype"),
+       url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.svg') format("svg");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Use absolute paths for TS-UI fonts

The way that TS-UI is used makes it difficult to use a relative font path, since the root URL changes depending on how it is imported into different apps. Fonts are on the CDN via TS-UI, so this grabs that location. Fonts don't really need to be versioned, but they are right now, so this uses one of the earlier versions and shouldn't need updated unless we change our font stack.