### PR TITLE
Add wrapper around table rows with height prop

### DIFF
--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -151,9 +151,7 @@ class Table extends PureComponent {
   }
 
   render() {
-    const { isStriped, className, mods, style, otherProps } = this.props
-
-    const tableBodyHeight = this.props.tableBodyHeight || 'auto'
+    const { isStriped, className, mods, style, otherProps, tableBodyHeight } = this.props
 
     return (
       <Panel className={ className } mods={ mods } isStriped={ isStriped } style={ style } { ...otherProps }>
@@ -200,7 +198,8 @@ Table.defaultProps = {
   className: 'Panel',
   mods: null,
   style: {},
-  otherProps: {}
+  otherProps: {},
+  tableBodyHeight: 'auto'
 }
 
 export default Table

--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -153,11 +153,15 @@ class Table extends PureComponent {
   render() {
     const { isStriped, className, mods, style, otherProps } = this.props
 
+    const tableBodyHeight = this.props.tableBodyHeight || 'auto'
+
     return (
       <Panel className={ className } mods={ mods } isStriped={ isStriped } style={ style } { ...otherProps }>
         <PanelBody>
           <PanelRow isWithCells>{ this.renderTableColumns() }</PanelRow>
-          { this.renderTableRows() }
+          <div style={{height: tableBodyHeight, overflow: 'scroll' }}>
+            { this.renderTableRows() }
+          </div>
         </PanelBody>
       </Panel>
     )


### PR DESCRIPTION
We need the Table component body to be scrollable, while the table header is stationary. This PR adds a wrapper around the table row function where height and overflow are passed as inline styles. The value for height is `tableBodyHeight` prop. The default for `tableBodyHeight` is `auto`.

@saralohr Is this what you had in mind?