### PR TITLE
Update items in local state when row props change and scroll table body

### DIFF
--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -47,6 +47,14 @@ class Table extends PureComponent {
     this.setState({ ...tableState })
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { rows } = this.props
+
+    if (prevProps.rows.length !== rows.length) {
+      this.setState({items: setUniqueId(rows)})
+    }
+  }
+
   sortItems = (newSort, newItems) => {
     const { columns } = this.props
 

--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -47,11 +47,11 @@ class Table extends PureComponent {
     this.setState({ ...tableState })
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const { rows } = this.props
 
     if (prevProps.rows.length !== rows.length) {
-      this.setState({items: setUniqueId(rows)})
+      this.setState({ items: setUniqueId(rows) })
     }
   }
 
@@ -159,18 +159,18 @@ class Table extends PureComponent {
   }
 
   render() {
-    const { isStriped, className, mods, style, otherProps } = this.props
+    const { isStriped, className, mods, style, otherProps, maxTableHeight } = this.props
 
     return (
       <Panel className={ className } mods={ mods } isStriped={ isStriped } style={ style } { ...otherProps }>
         <PanelBody>
           <PanelRow isWithCells>{ this.renderTableColumns() }</PanelRow>
-          {otherProps.scrollTableBody &&
-            <div style={{height: otherProps.tableBodyHeight, overflow: 'scroll'}}>
+          { maxTableHeight &&
+            <div style={{ height: maxTableHeight, overflow: 'scroll' }}>
               { this.renderTableRows() }
             </div>
           }
-          {!otherProps.scrollTableBody &&
+          { !maxTableHeight &&
             this.renderTableRows()
           }
         </PanelBody>
@@ -200,7 +200,8 @@ Table.propTypes = {
   className: PropTypes.string,
   mods: PropTypes.string,
   style: PropTypes.object,
-  otherProps: PropTypes.object
+  otherProps: PropTypes.object,
+  maxTableHeight: PropTypes.number
 }
 
 Table.defaultProps = {
@@ -211,7 +212,8 @@ Table.defaultProps = {
   className: 'Panel',
   mods: null,
   style: {},
-  otherProps: {}
+  otherProps: {},
+  maxTableHeight: null
 }
 
 export default Table

--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -201,7 +201,7 @@ Table.propTypes = {
   mods: PropTypes.string,
   style: PropTypes.object,
   otherProps: PropTypes.object,
-  maxTableHeight: PropTypes.number
+  maxTableHeight: PropTypes.string
 }
 
 Table.defaultProps = {

--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -165,7 +165,14 @@ class Table extends PureComponent {
       <Panel className={ className } mods={ mods } isStriped={ isStriped } style={ style } { ...otherProps }>
         <PanelBody>
           <PanelRow isWithCells>{ this.renderTableColumns() }</PanelRow>
-          { this.renderTableRows() }
+          {otherProps.scrollTableBody &&
+            <div style={{height: otherProps.tableBodyHeight, overflow: 'scroll'}}>
+              { this.renderTableRows() }
+            </div>
+          }
+          {!otherProps.scrollTableBody &&
+            this.renderTableRows()
+          }
         </PanelBody>
       </Panel>
     )


### PR DESCRIPTION
Table component `items` state is only set when the component mounts, not when props update.

This PR adds a conditional check in `componentDidUpdate` method and updates `items` state accordingly. Also adds a div around table body for scrolling.