### PR TITLE
Use // to work for both http and https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [2.12.0] - 2018-06-15
+https://github.com/teamsnap/teamsnap-ui/pull/95
+### Changed
+- Change font path to just `//` so they can work for http and https
+
 ## [2.11.0] - 2018-06-12
 https://github.com/teamsnap/teamsnap-ui/pull/94
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "scripts": {

--- a/src/css/fonts/museo.scss
+++ b/src/css/fonts/museo.scss
@@ -6,60 +6,60 @@
 
 @font-face {
   font-family: 'MuseoSansRounded100Regular';
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.eot');
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.woff') format('woff'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.ttf') format('truetype'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.svg') format('svg');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.eot');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.woff') format('woff'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.ttf') format('truetype'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-100-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded300Regular';
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.eot');
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.woff') format('woff'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.ttf') format('truetype'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.svg') format('svg');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.eot');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.woff') format('woff'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.ttf') format('truetype'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-300-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded500Regular';
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.eot');
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.woff') format('woff'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.ttf') format('truetype'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.svg') format('svg');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.eot');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.woff') format('woff'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.ttf') format('truetype'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-500-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded700Regular';
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.eot');
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.woff') format('woff'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.ttf') format('truetype'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.svg') format('svg');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.eot');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.woff') format('woff'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.ttf') format('truetype'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-700-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded900Regular';
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.eot');
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.woff') format('woff'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.ttf') format('truetype'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.svg') format('svg');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.eot');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.woff') format('woff'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.ttf') format('truetype'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-900-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'MuseoSansRounded1000Regular';
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.eot');
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.woff') format('woff'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.ttf') format('truetype'),
-    url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.svg') format('svg');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.eot');
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.woff') format('woff'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.ttf') format('truetype'),
+    url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/museo/MuseoSansRounded-1000-webfont.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/css/fonts/ss-pika.scss
+++ b/src/css/fonts/ss-pika.scss
@@ -15,10 +15,10 @@
 
 @font-face {
   font-family: "SSPika";
-  src: url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.eot'),
-       url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.woff') format("woff"),
-       url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.ttf') format("truetype"),
-       url('http://dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.svg') format("svg");
+  src: url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.eot'),
+       url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.woff') format("woff"),
+       url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.ttf') format("truetype"),
+       url('//dugout.teamsnap.com/teamsnap-ui/2.5.1/assets/fonts/ss-pika/ss-pika.svg') format("svg");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
I just noticed that the fonts weren't working in UI-Patterns with Classic CSS turned off. I only tested this locally on http, but it needs to work on https too. Using `//dugout` so it works for both, unless there is some better way to do this? 