### PR TITLE
making the feedback popup component more flexible

### DIFF
--- a/src/css/components/Feedback.scss
+++ b/src/css/components/Feedback.scss
@@ -108,10 +108,12 @@
 .Feedback--popup {
   position: fixed;
   top: -100%;
-  width: 25%;
+  width: calc(100% - #{($su-medium * 2)});
+  max-width: scaleGrid(50);
   right: $su-medium;
   box-shadow: $box-shadow-large;
   transition: top $duration-short;
+  z-index: 9999;
   &.js-active {
     top: $su-medium;
     transition: top $duration-short;


### PR DESCRIPTION
Just a quick fix for this issue..

before:

![image-2018-08-09-07-57-35-052](https://user-images.githubusercontent.com/1189536/43925629-f9b60b3e-9be4-11e8-95a9-0347e6e46e8e.png)

after:

<img width="400" alt="screen shot 2018-08-09 at 3 02 22 pm" src="https://user-images.githubusercontent.com/1189536/43925735-54e6b2a6-9be5-11e8-8c8d-2992d35469f0.png">