### PR TITLE
adding a placeholder text option for empty tables

### DIFF
--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -31,6 +31,7 @@ import PanelBody from '../PanelBody'
 import PanelRow from '../PanelRow'
 import PanelCell from '../PanelCell'
 import TextLink from '../TextLink'
+import Loader from '../Loader'
 
 class Table extends PureComponent {
   state = {
@@ -153,13 +154,23 @@ class Table extends PureComponent {
     return columns.map(this.renderHeaderColumn)
   }
 
-  renderTableRows = () => {
+  renderTableRows = (placeHolder, isLoading) => {
     const { items } = this.state
-    return items.map(this.renderRow)
+    if (isLoading) {
+      return  (
+        <div className='u-padMd u-textCenter'>
+          <Loader type='spin' text='loading...' />
+        </div>
+      )
+    }
+    if (!isLoading && items.length) {
+      return items.map(this.renderRow)
+    }
+    return <div className='u-padMd u-textCenter'>{ placeHolder }</div>
   }
 
   render() {
-    const { isStriped, className, mods, style, otherProps, maxTableHeight } = this.props
+    const { isStriped, className, mods, style, otherProps, maxTableHeight, placeHolder, isLoading } = this.props 
 
     return (
       <Panel className={ className } mods={ mods } isStriped={ isStriped } style={ style } { ...otherProps }>
@@ -172,7 +183,7 @@ class Table extends PureComponent {
 
           }
           { !maxTableHeight &&
-            this.renderTableRows()
+            this.renderTableRows(placeHolder, isLoading)
           }
         </PanelBody>
       </Panel>
@@ -202,7 +213,12 @@ Table.propTypes = {
   mods: PropTypes.string,
   style: PropTypes.object,
   otherProps: PropTypes.object,
-  maxTableHeight: PropTypes.string
+  maxTableHeight: PropTypes.string,
+  isLoading: PropTypes.bool,
+  placeHolder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ])
 }
 
 Table.defaultProps = {
@@ -214,7 +230,9 @@ Table.defaultProps = {
   mods: null,
   style: {},
   otherProps: {},
-  maxTableHeight: null
+  placeHolder: 'Nothing to see here',
+  maxTableHeight: null,
+  isLoading: false
 }
 
 export default Table


### PR DESCRIPTION
adding a placeholder option to the table component for empty states

relates to https://teamsnap.atlassian.net/browse/TP-667

<img width="1491" alt="Screen Shot 2019-04-25 at 12 45 55 PM" src="https://user-images.githubusercontent.com/1189536/56760361-40980b80-6758-11e9-90af-94418980ba97.png">
<img width="1486" alt="Screen Shot 2019-04-25 at 12 46 24 PM" src="https://user-images.githubusercontent.com/1189536/56760362-40980b80-6758-11e9-9163-66ba2ea59353.png">
<img width="1494" alt="Screen Shot 2019-04-25 at 12 46 43 PM" src="https://user-images.githubusercontent.com/1189536/56760363-40980b80-6758-11e9-8d59-1c6a6df851d9.png">

