### PR TITLE
Add color utilities

### DIFF
--- a/src/css/components/Daypicker.scss
+++ b/src/css/components/Daypicker.scss
@@ -1,0 +1,28 @@
+@import "../config/index.scss";
+
+// * WIP - Daypicker
+// * This is a stop-gap for styling themed calendars
+// * until we import a calendar component into TS-UI
+// * Applies to react DayPicker
+
+
+.DayPicker-Day:not(.DayPicker-Day--outside) {
+  &:hover {
+    background-color: adjust-color($cu-info--light, $alpha: -0.8);
+  }
+  &.DayPicker-Day--event {
+    border-color: scaleColor($cu-primary, 4);
+  }
+  &.DayPicker-Day--game {
+    background: $cu-primary;
+    color: $cu-foreground;
+  }
+}
+
+legend.game:before {
+  background-color: $cu-primary;
+}
+
+legend.event:before {
+  border-color: scaleColor($cu-primary, 4);
+}

--- a/src/css/themes/blue-steel.scss
+++ b/src/css/themes/blue-steel.scss
@@ -68,6 +68,7 @@ $cu-highlight--dark:        scaleColor($cu-highlight, 0);
 $cu-highlight--bg:         scaleColor($cu-highlight, 10);
 
 $color-links:                         $cu-primary--light;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Redefine Element Variables for Theme
 

--- a/src/css/themes/care-bear.scss
+++ b/src/css/themes/care-bear.scss
@@ -68,6 +68,7 @@ $cu-highlight--dark:       scaleColor($cu-highlight, -1);
 $cu-highlight--bg:         scaleColor($cu-highlight, 10);
 
 $color-links:                                    #469ee4;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app-theme with redefined variables
 

--- a/src/css/themes/christmas-sweater.scss
+++ b/src/css/themes/christmas-sweater.scss
@@ -74,6 +74,7 @@ $cu-negative--dark:         scaleColor($cu-negative, -1);
 $cu-negative--bg:            scaleColor($cu-negative, 8);
 
 $color-links:                                $cu-primary;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Redefine Element Variable Settings
 

--- a/src/css/themes/custom-aquablue.scss
+++ b/src/css/themes/custom-aquablue.scss
@@ -18,6 +18,7 @@ $cu-primary:   #008080;
 $cu-secondary: #2D9595;
 $cu-highlight: #004D4D;
 $color-links:  #3DCCCC;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-black.scss
+++ b/src/css/themes/custom-black.scss
@@ -18,6 +18,7 @@ $cu-primary:   #000;
 $cu-secondary: #666;
 $cu-highlight: #777;
 $color-links:  #888;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-blue.scss
+++ b/src/css/themes/custom-blue.scss
@@ -18,6 +18,7 @@ $cu-primary:   #1269b1;
 $cu-secondary: #4C8BBE;
 $cu-highlight: #0D4B7E;
 $color-links:  #1A96FD;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-darkblue.scss
+++ b/src/css/themes/custom-darkblue.scss
@@ -18,6 +18,7 @@ $cu-primary:   #153b5b;
 $cu-secondary: #5984A7;
 $cu-highlight: #3E5C74;
 $color-links:  #276DA7;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-darkgreen.scss
+++ b/src/css/themes/custom-darkgreen.scss
@@ -18,6 +18,7 @@ $cu-primary:   #004d00;
 $cu-secondary: #1F661F;
 $cu-highlight: #2E992E;
 $color-links:  #009900;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-darkred.scss
+++ b/src/css/themes/custom-darkred.scss
@@ -18,6 +18,7 @@ $cu-primary:   #8B0000;
 $cu-secondary: #9E2F2F;
 $cu-highlight: #D74141;
 $color-links:  #D70000;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-goldenyellow.scss
+++ b/src/css/themes/custom-goldenyellow.scss
@@ -18,6 +18,7 @@ $cu-primary:   #cc9900;
 $cu-secondary: #D4AF40;
 $cu-highlight: #997300;
 $color-links:  #4C3900;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-gray.scss
+++ b/src/css/themes/custom-gray.scss
@@ -18,6 +18,7 @@ $cu-primary:   #999;
 $cu-secondary: #666;
 $cu-highlight: #222;
 $color-links:  #888;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-green.scss
+++ b/src/css/themes/custom-green.scss
@@ -18,6 +18,7 @@ $cu-primary:   #1a801a;
 $cu-secondary: #4B954B;
 $cu-highlight: #104D10;
 $color-links:  #4B954B;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-leafgreen.scss
+++ b/src/css/themes/custom-leafgreen.scss
@@ -18,6 +18,7 @@ $cu-primary:   #4d801a;
 $cu-secondary: #70954B;
 $cu-highlight: #2E4D10;
 $color-links:  #70954B;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-lemonyellow.scss
+++ b/src/css/themes/custom-lemonyellow.scss
@@ -18,6 +18,7 @@ $cu-primary:   #ffcd00;
 $cu-secondary: #ffcd00;
 $cu-highlight: #CCA400;
 $color-links:  #7F6600;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-lightblue.scss
+++ b/src/css/themes/custom-lightblue.scss
@@ -18,6 +18,7 @@ $cu-primary:   #80aaff;
 $cu-secondary: #80aaff;
 $cu-highlight: #40557F;
 $color-links:  #6688CC;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-orange.scss
+++ b/src/css/themes/custom-orange.scss
@@ -18,6 +18,7 @@ $cu-primary:   #d97e00;
 $cu-secondary: #D97E00;
 $cu-highlight: #593400;
 $color-links:  #A66000;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-pink.scss
+++ b/src/css/themes/custom-pink.scss
@@ -18,6 +18,7 @@ $cu-primary:   #f2798d;
 $cu-secondary: #f2798d;
 $cu-highlight: #723943;
 $color-links:  #BF5F6F;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-purple.scss
+++ b/src/css/themes/custom-purple.scss
@@ -18,6 +18,7 @@ $cu-primary:   #660066;
 $cu-secondary: #7F267F;
 $cu-highlight: #B236B2;
 $color-links:  #B200B2;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/custom-red.scss
+++ b/src/css/themes/custom-red.scss
@@ -18,6 +18,7 @@ $cu-primary:   #cc0000;
 $cu-secondary: #cc0000;
 $cu-highlight: #990000;
 $color-links:  #4C0000;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/maple-leaf.scss
+++ b/src/css/themes/maple-leaf.scss
@@ -19,6 +19,7 @@ $cu-primary--dark:   #990000;
 $cu-secondary:       #C61C22;
 $cu-highlight:       #383838;
 $color-links:        #990000;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app.scss with color settings overrriden
 

--- a/src/css/themes/portland-oregon.scss
+++ b/src/css/themes/portland-oregon.scss
@@ -68,6 +68,7 @@ $cu-highlight--dark:       scaleColor($cu-highlight, -1);
 $cu-highlight--bg:         scaleColor($cu-highlight, 10);
 
 $color-links:                                    #417f8c;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app-theme with redefined variables
 

--- a/src/css/themes/ranger-smith.scss
+++ b/src/css/themes/ranger-smith.scss
@@ -68,6 +68,7 @@ $cu-highlight--dark:       scaleColor($cu-highlight, -1);
 $cu-highlight--bg:         scaleColor($cu-highlight, 10);
 
 $color-links:                                    #6b9a07;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Load app-theme with redefined variables
 

--- a/src/css/themes/up-beet.scss
+++ b/src/css/themes/up-beet.scss
@@ -69,6 +69,7 @@ $cu-highlight--dark:        scaleColor($cu-highlight, 0);
 $cu-highlight--bg:         scaleColor($cu-highlight, 10);
 
 $color-links:                         $cu-primary--light;
+$color-links--hover: scaleColor($color-links, -2);
 
 // * 2. Redefine Element Variables for Theme
 

--- a/src/css/utils/color.scss
+++ b/src/css/utils/color.scss
@@ -26,6 +26,10 @@
   color: $cu-highlight !important;
 }
 
+.u-colorForeground {
+  color: $cu-foreground !important;
+}
+
 
 // * Link Colors (other than default)
 
@@ -34,4 +38,30 @@
   &:hover, &:active {
     color: scaleColor($cu-negative, -1) !important;
   }
+}
+
+// * BG colors
+
+.u-bgPositive {
+  background-color: $cu-positive !important;
+}
+
+.u-bgNegative {
+  background-color: $cu-negative !important;
+}
+
+.u-bgPrimary {
+  background-color: $cu-primary !important;
+}
+
+.u-bgSecondary {
+  background-color: $cu-secondary !important;
+}
+
+.u-bgHighlight {
+  background-color: $cu-highlight !important;
+}
+
+.u-bgLinkLight {
+  background-color: scaleColor($color-links, 8) !important;
 }


### PR DESCRIPTION
- Adds background color utilities for main themed colors, positive, negative
- Adds background utility based off link color - provides a light bg for links
- Adds a foreground color utility for text on color
- Includes the link hover state in each theme, currently these are compiling with the default link color, so links hover to blue
- WIP - Adds initital styles for Daypicker component

<img width="698" alt="Screen Shot 2019-05-10 at 1 27 01 PM" src="https://user-images.githubusercontent.com/9888467/57548730-56482c00-7327-11e9-982e-dc8fa9729141.png">
