### PR TITLE
WIP - Invitations updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [2.17.1] - 2019-06-11
+
+- https://github.com/teamsnap/teamsnap-ui/pull/120
+
+### Changed
+
+- `Added` assorted CSS utilites (see PR)
+- `Updated` CSS/design for Checkbox, Input and SelectBox
+- `Updated` StepNav to add xs modifier and support for numbers
+
+
 ## [2.16.1] - 2019-06-05
 
 - https://github.com/teamsnap/teamsnap-ui/pull/124

--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ https://teamsnap-ui-patterns.netlify.com/
 - [ ] Popup
 - [ ] Modal
 - [ ] Tab
+- [ ] Input Show Hide

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.15.1",
+  "version": "2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "2.16.1",
+  "version": "2.17.1",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "scripts": {

--- a/src/css/components/Checkbox.scss
+++ b/src/css/components/Checkbox.scss
@@ -7,115 +7,199 @@
 // * 2. Default Checkbox
 // * 3. Radio Checkbox
 // * 4. Inline Checkbox
+// * 5. Pill Checkbox
+// * 6. Large Checkbox
+// * 7. Color Primary Checkbox
 
 // Notes:
 // * disabling a checkbox only needs to be done on the input
-
-// TODO: look into large modifier for default checkbox
-// TODO: look into svg icons for checkboxes
-// TODO: fix cursor conflict in classic
 
 //------------------------------------------------------------//
 
 // * 1. Checkbox Settings
 
-$Checkbox-size: scaleGrid(2) !default;
-$Checkbox-icon-size: scaleFont($fontSize, -3) !default;
+$Checkbox-size: $su-medium;
+$Checkbox-radioPadding: 3px;
+
+$Checkbox-size--large: 22px; // Allows pill version to be 40px (same as large button and input)
+$Checkbox-radioPadding--large: $su-xsmall;
+
+$Checkbox-color: $cu-positive !default;
 $Checkbox-bg-color: $cu-foreground !default;
+
+@mixin Checkbox--defineSize($size, $radioPadding) {
+  .Checkbox-input {
+    height: $size;
+    width: $size;
+  }
+
+  .Checkbox-label {
+    padding-left: $size + $su-small;
+    min-height: $size;
+    line-height: $size;
+
+    &:before {
+      height: $size;
+      width: $size;
+    }
+  }
+
+  &.Checkbox--pill {
+    .Checkbox-label {
+      padding-left: $size + $su-medium;
+
+      &:before {
+        top: 50%;
+        margin-top: ($size / 2) * -1;
+        // Centers radio in Pill if text wraps
+      }
+    }
+  }
+
+  &.Checkbox--radio {
+    .Checkbox-label:before {
+      box-shadow: inset 0 0 0 $size #fff;
+      // Transitions to narrow inner radius of checked radio
+    }
+
+    .Checkbox-input:checked:not(:disabled) + .Checkbox-label:before {
+      box-shadow: inset 0 0 0 $radioPadding #fff;
+      // Creates inner radius for radio button
+    }
+  }
+}
+
+@mixin Checkbox--defineColor($color) {
+  // Active state
+  .Checkbox-input:checked + .Checkbox-label:before {
+    background-color: $color;
+  }
+
+  // Hover and focus states
+  .Checkbox-input:not(:disabled) {
+    & + .Checkbox-label:hover:before,
+    & + .Checkbox-label:focus:before,
+    &:hover + .Checkbox-label:before,
+    &:focus + .Checkbox-label:before {
+      border-color: $color;
+    }
+  }
+
+  // Disabled state
+  .Checkbox-input:disabled:checked + .Checkbox-label {
+    &:before {
+      background-color: $color;
+    }
+  }
+
+  // Radio
+  &.Checkbox--radio {
+    .Checkbox-input:checked:not(:disabled) + .Checkbox-label:before {
+      border-color: $color;
+    }
+  }
+
+  // Pill
+  &.Checkbox--pill {
+    .Checkbox-label {
+      &:hover, &:focus {
+        border-color: $color;
+      }
+    }
+    .Checkbox-input:checked + .Checkbox-label {
+      border-color: $color;
+      background-color: scaleColor($color, 9.5);
+    }
+  }
+}
 
 // * 2. Default Checkbox
 
 .Checkbox {
+  @include Checkbox--defineSize($Checkbox-size, $Checkbox-radioPadding);
+  @include Checkbox--defineColor($Checkbox-color);
+
   position: relative;
   padding-bottom: $su-medium;
 }
 
 .Checkbox-input {
   opacity: 0;
-  height: $Checkbox-size;
-  width: $Checkbox-size;
   cursor: pointer;
   z-index: 5;
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
+  margin: 0;
 }
 
 .Checkbox-label {
   position: relative;
   display: block;
   cursor: pointer;
-  padding-left: $Checkbox-size + $su-xsmall;
-  min-height: $Checkbox-size;
 
   &:before {
-    @include ss-pika;
     content: '';
     display: block;
     cursor: pointer;
-    color: $ts-white;
-    text-align: center;
-    font-size: $Checkbox-icon-size;
-    height: $Checkbox-size;
-    width: $Checkbox-size;
-    line-height: $Checkbox-size + 1; // ss-pika checkmark sits up high
     background-color: $Checkbox-bg-color;
-    box-shadow: $inset-box-shadow-small;
     border: $border-width-small solid $cu-divider;
     border-radius: $border-radius-small;
-    margin: auto;
+    margin: 0;
     position: absolute;
     left: 0;
     top:  0;
     bottom: 0;
+    transition: all ease 0.2s;
+    background-size: 75%;
+    background-repeat: no-repeat;
+    background-position: center center;
   }
 }
 
-.Checkbox-input:checked {
-  & + .Checkbox-label:before {
-    content: '✓';
-    background-color: $cu-positive;
-    box-shadow: none;
+// Active state
+.Checkbox-input:checked + .Checkbox-label:before {
+  background-image: url("data:image/svg+xml; utf8, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 960 960'%3E%3Cpath fill='white' d='M915 178.9c8 6.7 12.3 15.5 13 26.5s-2.3 21.2-9 30.5c-252.7 360.7-389.3 555.3-410 584-21.3 28.7-48.8 43.2-82.5 43.5S365 849.2 343 819.9l-278-391c-6.7-9.3-9.7-19.7-9-31s5-20.3 13-27c34-29.3 72-55.7 114-79 8.7-4.7 18.3-5.3 29-2s19.3 9.7 26 19l188 264 321-456c6.7-9.3 15.2-15.5 25.5-18.5s20.2-2.2 29.5 2.5c44 24 81.7 50 113 78z'%3E%3C/path%3E%3C/svg%3E");
+  // SVG check icon
+  border: none;
+}
+
+// Disabled state
+.Checkbox-input:disabled,
+.Checkbox-input:disabled + .Checkbox-label {
+  &, &:before {
+    cursor: not-allowed;
+  }
+
+  &:before {
+    background-image: url("data:image/svg+xml; utf8, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 960 960'%3E%3Cpath fill='white' d='M829,500.82V843.87A58.74,58.74,0,0,1,813.63,884a69.15,69.15,0,0,1-37.18,22.31A1302.73,1302.73,0,0,1,480,940q-154.67,0-299.43-33.71A63.46,63.46,0,0,1,131,843.87V503.8a76.16,76.16,0,0,1,17.85-49.57q17.85-21.81,43.63-21.81h33.71V273.77q0-114,69.9-183.92T480,20q114,0,183.92,69.9t69.9,183.92V432.41h30.74q25.78,0,45.11,20.82T829,500.82ZM384.82,432.41H575.18V273.77q0-95.18-95.18-95.18t-95.18,95.18Z'%3E%3C/path%3E%3C/svg%3E");
+    // SVG lock icon
+    background-color: $cu-divider;
     border: none;
   }
 }
 
-.Checkbox-input:disabled + .Checkbox-label {
-  
-  &, &:before {
-    cursor: default; // not-allowed would be nice, but is conflicting with classic
-  }
-
-  &:before {
-    content: '🔒';
-    box-shadow: none;
-    background-color: $cu-divider;
-    line-height: $Checkbox-size;
-    color: $Checkbox-bg-color;
-  }
-}
-
-.Checkbox-input:disabled:checked + .Checkbox-label {
-  &:before {
-    background-color: $cu-positive;
-  }
-}
-
-.Checkbox-input,
-.Checkbox-input:checked {
-  &:focus + .Checkbox-label:before {
-    box-shadow: 0px 0px 2px 2px highlight;
-  }
-}
 
 // * 3. Radio Checkbox
 
 .Checkbox--radio {
   .Checkbox-label:before {
-    border-radius: ( $Checkbox-size / 2 );
+    border-radius: 50%; // Make it a circle
+    background-image: none;
+  }
+
+  .Checkbox-input:checked:not(:disabled) + .Checkbox-label:before {
+    border-style: solid;
+    border-width: $border-width-small; // Add a border to define the radius
+    background-image: none; // Remove check icon
+  }
+
+  .Checkbox-input:disabled + .Checkbox-label:before {
+    box-shadow: none; // Remove inner radius
   }
 }
+
 
 // * 4. Inline Checkbox
 
@@ -131,5 +215,32 @@ $Checkbox-bg-color: $cu-foreground !default;
       left: $su-small;
     }
   }
+}
 
+// * 5. Pill checkbox button
+
+.Checkbox--pill {
+  .Checkbox-label {
+    border: solid $border-width-small $cu-divider;
+    border-radius: $su-xlarge;
+    padding: $su-small;
+    transition: all ease 0.2s;
+
+    &:before {
+      left: $su-small;
+    }
+  }
+}
+
+// * 6. Large Checkbox
+
+.Checkbox--large {
+  @include Checkbox--defineSize($Checkbox-size--large, $Checkbox-radioPadding--large);
+}
+
+
+// * 7. Color Primary
+
+.Checkbox--colorPrimary {
+  @include Checkbox--defineColor($cu-primary);
 }

--- a/src/css/components/FieldGroup.scss
+++ b/src/css/components/FieldGroup.scss
@@ -50,7 +50,7 @@ $FieldGroup-font-size: $tu-base-fontSize;
 // * 3. Form Group States
 
 .FieldGroup.is-notValid {
-  .Input, .Checkbox-label:before, .SelectBox-options, textarea {
+  .Input, .Checkbox-label:before, .SelectBox-options, textarea, .Checkbox--pill .Checkbox-label {
     border-color: $cu-negative;
   }
 }

--- a/src/css/components/Input.scss
+++ b/src/css/components/Input.scss
@@ -67,3 +67,44 @@ input:-webkit-autofill:focus {
   height: $su-xxlarge;
   line-height: $su-xxlarge;
 }
+
+$Input--showHideWidth: scaleGrid(7); // 56px
+
+.Input--showHide {
+  padding-right: $Input--showHideWidth;
+  // Set padding to width of show/hide control
+  // so native field controls are not covered
+  // (such as Safari's password manager tool)
+}
+
+.Input-showHideButton {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: $Input--showHideWidth;
+  height: 100%;
+  background-color: transparent;
+  border: none;
+  color: $cu-info--light;
+  border-radius: 0 $border-radius-medium $border-radius-medium 0;
+  font-size: $tu-base-fontSize;
+  font-weight: normal;
+  font-family: inherit;
+  line-height: 1;
+  padding: $su-small;
+  transition: all ease 200ms;
+  cursor: pointer;
+}
+
+.Input-showHideButton:hover {
+  background-color: transparent;
+  color: $cu-info;
+}
+
+.Input-showHideButton:focus {
+  outline: none;
+  border: solid 1px $cu-primary;
+  background-color: transparent;
+  color: $cu-info;
+}

--- a/src/css/components/Input.scss
+++ b/src/css/components/Input.scss
@@ -30,17 +30,23 @@ $form-input-bg-color: $cu-foreground--dark !default;
   line-height: $form-input-line-height;
   padding: 0 $su-small;
   box-sizing: border-box;
-  box-shadow: $inset-box-shadow-medium;
+  box-shadow: none;
   background-color: $form-input-bg-color;
   border: $border-width-small solid $cu-divider;
   border-radius: $border-radius-medium;
   font-family: inherit;
   font-size: $tu-base-fontSize;
+  transition: all ease 0.2s;
 
   &:disabled {
     background: $cu-middleground--dark;
     color: $ts-grey;
     cursor: not-allowed;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: $cu-primary;
   }
 
   &::-ms-clear {

--- a/src/css/components/SelectBox.scss
+++ b/src/css/components/SelectBox.scss
@@ -11,7 +11,6 @@
 // * 1. Select Box Settings
 
 $SelectBox-bg-color: $cu-foreground--dark !default;
-$SelectBox-bg-color--hover: scaleColor($cu-foreground--dark, -1) !default;
 $SelectBox-text-color: $cu-info !default;
 $SelectBox-height: $su-xlarge !default;
 $SelectBox-indicator-width: scaleGrid(4);
@@ -63,14 +62,10 @@ $SelectBox-indicator-width: scaleGrid(4);
     display: none;
   }
 
-  // Apply the IE and Edge native focus style
-  &:focus::-ms-value {
-    background: highlight;
-    color: white;
-  }
-
-  &:hover:not(:disabled):not(.is-disabled) {
-    background: $SelectBox-bg-color--hover;
+  // Focus state
+  &:focus {
+    border-color: $cu-primary;
+    outline: none;
   }
 
   &:disabled,

--- a/src/css/components/StepNav.scss
+++ b/src/css/components/StepNav.scss
@@ -5,9 +5,8 @@
 // * StepNav Component
 // * 1. Settings
 // * 2. Define Default StepNav
-// * 3. Size Modifier Mixin
-// * 4. Small Modifier
-// * 5. Titled Modifier
+// * 3. Small Modifier
+// * 4. Titled Modifier
 
 // TODO : document global dependencies
 // TODO : further responsive cleanup, especially on titled setp nav
@@ -19,10 +18,65 @@
 $StepNav-size: scaleGrid(7);
 $StepNav-spacing: scaleGrid(-1);
 $StepNav-titleWidth: 150px;
-$StepNav-paddedWidth: $StepNav-size + ($StepNav-spacing * 2);
 
 $StepNav-size--small: scaleGrid(5);
 $StepNav-spacing--small: scaleGrid(-2);
+
+$StepNav-size--xsmall: scaleGrid(3);
+$StepNav-spacing--xsmall: scaleGrid(-3);
+
+// * Define sizes
+
+@mixin StepNav--defineSize($size, $spacing) {
+
+  // define paddedWidth based on size and spacing
+  $paddedWidth: $size + ($spacing * 2);
+
+  .StepNav-steps {
+    padding-left: $paddedWidth;
+  }
+
+  .StepNav-step {
+    &:before {
+      width: calc(100% - #{$paddedWidth});
+      height: $spacing;
+      top: ($size / 2);
+      right: $paddedWidth;
+    }
+    &.is-active,
+    &.is-enabled a:hover {
+      .StepNav-stepIcon {
+        box-shadow: 0 0 ($spacing / 2) $cu-primary--dark inset;
+      }
+    }
+    &.is-enabled a:hover {
+      .StepNav-stepIcon {
+        box-shadow: 0 0 ($spacing / 2) $cu-primary--dark inset;
+      }
+    }
+  }
+
+  .StepNav-stepLink {
+    padding: 0 $spacing;
+  }
+
+  .StepNav-stepTitle {
+    width: $StepNav-titleWidth;
+    left: calc( 0px - #{(($StepNav-titleWidth - $paddedWidth) / 2)});
+    padding-top: $spacing;
+  }
+
+  .StepNav-stepIcon {
+    font-size: $size * .4;
+    border: {
+      width: $spacing;
+    }
+    height: $size;
+    width: $size;
+    border-radius: ($size / 2);
+    padding: $size * .25;
+  }
+}
 
 // * 2. Define Default StepNav
 
@@ -30,8 +84,9 @@ $StepNav-spacing--small: scaleGrid(-2);
   padding-bottom: $su-large;
 }
 
+@include StepNav--defineSize($StepNav-size, $StepNav-spacing);
+
 .StepNav-steps {
-  padding-left: $StepNav-paddedWidth;
   position: relative;
   padding-bottom: $su-xsmall;
   display: flex;
@@ -46,13 +101,9 @@ $StepNav-spacing--small: scaleGrid(-2);
 
   &:before {
     content: '';
-    width: calc(100% - #{$StepNav-paddedWidth});
     display: block;
     position: absolute;
     background: $cu-divider;
-    height: $StepNav-spacing;
-    top: ($StepNav-size / 2);
-    right: ($StepNav-paddedWidth);
   }
 
   &:first-child {
@@ -87,15 +138,13 @@ $StepNav-spacing--small: scaleGrid(-2);
   &.is-enabled .StepNav-stepLink:hover {
     .StepNav-stepIcon {
       color: $ts-white;
-      box-shadow: 0 0 ($StepNav-spacing / 2) $cu-primary--dark inset;
       border-color: $cu-divider;
       background-color: $cu-primary;
     }
   }
-    &.is-enabled .StepNav-stepLink:hover {
-    svg.StepNav-stepIcon {
+  &.is-enabled .StepNav-stepLink:hover {
+    .StepNav-stepIcon {
       color: $ts-white;
-      box-shadow: 0 0 ($StepNav-spacing / 2) $cu-primary--dark inset;
       border-color: $cu-divider;
       background-color: $cu-primary;
     }
@@ -107,7 +156,6 @@ $StepNav-spacing--small: scaleGrid(-2);
   position: relative;
   z-index: 10;
   color: $cu-divider;
-  padding: 0 $StepNav-spacing;
 }
 
 .StepNav-stepTitle {
@@ -118,74 +166,22 @@ $StepNav-spacing--small: scaleGrid(-2);
   font-family: $tu-openSans-fontFamily;
   font-size: $tu-base-fontSize;
   position: absolute;
-  width: $StepNav-titleWidth;
   top: 100%;
-  left: calc( 0px - #{(($StepNav-titleWidth - $StepNav-paddedWidth) / 2)});
-  padding-top: $StepNav-spacing;
 }
 
 .StepNav-stepIcon {
-  width: $StepNav-size;
   background: #fff;
   box-sizing: content-box;
-  line-height: $StepNav-size;
-    display: inline-block;
-    box-sizing: border-box;
-    vertical-align: middle;
-    height: $StepNav-size;
-    width: $StepNav-size;
-    border-radius: ($StepNav-size / 2);
-    line-height: inherit;
-    padding: ($su-small * 1.3);
-    border: {
-      style: solid;
-      color: $cu-divider;
-      width: $StepNav-spacing;
-    }
-}
+  line-height: 1;
+  display: inline-block;
+  box-sizing: border-box;
+  vertical-align: middle;
+  text-align: center;
+  font-weight: bold;
 
-// * 3. Modifier : Size Modifier Mixin
-
-@mixin StepNav--sizeModifier($size, $spacing) {
-  // redefine paddedWidth based on size and spacing
-  $paddedWidth: $size + ($spacing * 2);
-
-  // override CSS values to update stap nav size
-  padding-left: $paddedWidth;
-  .StepNav-step {
-    &:before {
-      width: calc(100% - #{$paddedWidth});
-      height: $spacing;
-      top: ($size / 2);
-      right: $paddedWidth;
-    }
-  }
-  .StepNav-stepLink {
-    padding: 0 $spacing;
-  }
-  .StepNav-stepTitle {
-    padding-top: $spacing;
-    width: $StepNav-titleWidth;
-  }
-  .StepNav-stepIcon {
-    width: $size;
-  }
-  .StepNav-stepIcon {
-    line-height: $size;
-    font-size: ($size * 0.43);
-    border: {
-      width: $spacing;
-    }
-    height: $size;
-    width: $size;
-    border-radius: ($size / 2);
-    line-height: inherit;
-  }
-  .is-active,
-  .is-enabled a:hover {
-    .StepNav-stepIcon {
-      box-shadow: 0 0 ($spacing / 2) $cu-primary--dark inset;
-    }
+  border: {
+    style: solid;
+    color: $cu-divider;
   }
 }
 
@@ -193,9 +189,19 @@ $StepNav-spacing--small: scaleGrid(-2);
 
 .StepNav--small {
 
-  .StepNav-steps {
-    @include StepNav--sizeModifier($StepNav-size--small, $StepNav-spacing--small)
+  @include StepNav--defineSize($StepNav-size--small, $StepNav-spacing--small);
+
+  .StepNav-stepTitle {
+    display: none;
   }
+
+}
+
+// * 5.5 Modifier : X-Small StepNav
+
+.StepNav--xsmall {
+
+  @include StepNav--defineSize($StepNav-size--xsmall, $StepNav-spacing--xsmall);
 
   .StepNav-stepTitle {
     display: none;

--- a/src/css/config/config.scss
+++ b/src/css/config/config.scss
@@ -164,6 +164,7 @@ $breakpoint-sm: 768px;
 $breakpoint-md: 992px;
 $breakpoint-lg: 1200px;
 
+$breakpoint-xxs-max: $breakpoint-xs - 1px;
 $breakpoint-xs-max: $breakpoint-sm - 1px;
 $breakpoint-sm-max: $breakpoint-md - 1px;
 $breakpoint-md-max: $breakpoint-lg - 1px;
@@ -176,6 +177,7 @@ $breakpoints: (
 );
 
 $max-breakpoints: (
+  'xxsMax':  $breakpoint-xxs-max,
   'xsMax':  $breakpoint-xs-max,
   'smMax':  $breakpoint-sm-max,
   'mdMax':  $breakpoint-md-max

--- a/src/css/utils/border.scss
+++ b/src/css/utils/border.scss
@@ -45,11 +45,38 @@ $border-style: 1px solid $cu-divider--light;
         .u-#{$bp-name}-border#{$name} {
           border-#{$value}: $border-style;
         }
-        
+
         .u-#{$bp-name}-border#{$name}None {
           border-#{$value}: 0;
         }
 
+      }
+    }
+  }
+}
+
+// Border Radius
+
+$border-radius: (
+  'None': 0,
+  'Sm': $border-radius-small,  // 2px
+  'Md': $border-radius-medium, // 4px
+  'Lg': $border-radius-large   // 8px
+);
+
+@each $name, $value in $border-radius {
+  .u-borderRadius#{$name} {
+    border-radius: $value !important;
+  }
+}
+
+@if $responsive == true {
+  @each $bp-name, $bp-value in $breakpoints {
+    @media (min-width: $bp-value) {
+      @each $name, $value in $border-radius {
+        .u-#{$bp-name}-borderRadius#{$name} {
+          border-radius: $value !important;
+        }
       }
     }
   }

--- a/src/css/utils/color.scss
+++ b/src/css/utils/color.scss
@@ -73,3 +73,19 @@
 .u-bgLinkLight {
   background-color: scaleColor($color-links, 8) !important;
 }
+
+.u-bgForeground {
+  background-color: $cu-foreground !important;
+}
+
+.u-bgBackground {
+  background-color: $cu-background !important;
+}
+
+// * Responsive, as necessary
+
+@media (min-width: $breakpoint-xs) {
+  .u-xs-bgForeground {
+    background-color: $cu-foreground !important;
+  }
+}

--- a/src/css/utils/display.scss
+++ b/src/css/utils/display.scss
@@ -12,6 +12,7 @@
   display: none !important;
 }
 
+
 // Completely remove from the flow but leave available to screen readers.
 
 .u-hiddenVisually {
@@ -35,6 +36,10 @@
 .u-inlineBlock {
   display: inline-block !important;
   max-width: 100%; // 1
+}
+
+.u-overflowHidden {
+  overflow: hidden !important;
 }
 
 @if $responsive == true {
@@ -69,6 +74,10 @@
       .u-#{$name}-inlineBlock {
         display: inline-block !important;
         max-width: 100%;
+      }
+
+      .u-#{$name}-overflowHidden {
+        overflow: hidden !important;
       }
     }
   }

--- a/src/css/utils/index.scss
+++ b/src/css/utils/index.scss
@@ -2,6 +2,8 @@
 @import "color";
 @import "display";
 @import "flex";
+@import "max-width";
+@import "position";
 @import "size";
 @import "space";
 @import "text";

--- a/src/css/utils/max-width.scss
+++ b/src/css/utils/max-width.scss
@@ -1,0 +1,15 @@
+$maxWidthbreakpoints: (
+  'Xs':  $breakpoint-xs,
+  'Sm':  $breakpoint-sm,
+  'Md':  $breakpoint-md,
+  'Lg': $breakpoint-lg
+);
+
+
+@if $responsive == true {
+  @each $name, $value in $maxWidthbreakpoints {
+    .u-maxWidth#{$name} {
+      max-width: #{$value} !important;
+    }
+  }
+}

--- a/src/css/utils/position.scss
+++ b/src/css/utils/position.scss
@@ -1,0 +1,7 @@
+.u-posRelative {
+  position: relative !important;
+}
+
+.u-posAbsolute {
+  position: absolute !important;
+}

--- a/src/css/utils/space.scss
+++ b/src/css/utils/space.scss
@@ -73,6 +73,11 @@ $spaces: (
   }
 }
 
+.u-spaceSidesAuto {
+  margin-right: auto !important;
+  margin-left: auto !important;
+}
+
 // * Responsive utilities
 
 @if $responsive == true {
@@ -119,6 +124,11 @@ $spaces: (
         .u-#{$bp-name}-padSides#{$name} {
          padding-left: $value !important;
         }
+      }
+
+      .u-#{$bp-name}-spaceSidesAuto {
+        margin-right: auto !important;
+        margin-left: auto !important;
       }
     }
   }

--- a/src/css/utils/text.scss
+++ b/src/css/utils/text.scss
@@ -24,27 +24,13 @@
   white-space: nowrap !important;
 }
 
+/**
+ * Text ellipsis
+ */
+
 .u-textEllipsis {
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-@if $responsive == true {
-  @each $name, $value in $breakpoints {
-    @media (min-width: $value) {
-      .u-#{$name}-textCenter {
-        text-align: center !important;
-      }
-
-      .u-#{$name}-textLeft {
-        text-align: left !important;
-      }
-
-      .u-#{$name}-textRight {
-        text-align: right !important;
-      }
-    }
-  }
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
 }
 
 
@@ -52,28 +38,19 @@
  * Font size utilities
  */
 
-.u-fontSizeXs {
-  font-size: $tu-xsmall-fontSize !important;
-}
+$fontSizes: (
+  'Xs': $tu-xsmall-fontSize,
+  'Sm': $tu-small-fontSize,
+  'Md': $tu-base-fontSize,
+  'Lg': $tu-large-fontSize,
+  'Xl': $tu-xlarge-fontSize,
+  'Xxl': $tu-xxlarge-fontSize
+);
 
-.u-fontSizeSm {
-  font-size: $tu-small-fontSize !important;
-}
-
-.u-fontSizeMd {
-  font-size: $tu-base-fontSize !important;
-}
-
-.u-fontSizeLg {
-  font-size: $tu-large-fontSize !important;
-}
-
-.u-fontSizeXl {
-  font-size: $tu-xlarge-fontSize !important;
-}
-
-.u-fontSizeXxl {
-  font-size: $tu-xxlarge-fontSize !important;
+@each $name, $value in $fontSizes {
+ .u-fontSize#{$name} {
+   font-size: #{$value} !important;
+ }
 }
 
 /**
@@ -81,25 +58,87 @@
  */
 
 .u-textNormal {
-  font-weight: $tu-base-fontWeight;
+  font-weight: $tu-base-fontWeight !important;
 }
 
 .u-textSemiBold {
-  font-weight: $tu-semibold-fontWeight;
+  font-weight: $tu-semibold-fontWeight !important;
 }
 
 .u-textBold {
-  font-weight: $tu-bold-fontWeight;
+  font-weight: $tu-bold-fontWeight !important;
 }
 
 /**
  * Text Decoration utilities
  */
 
- .u-textUnderline {
-  text-decoration: underline;
+.u-textUnderline {
+  text-decoration: underline !important;
 }
 
 .u-textLineThrough {
-  text-decoration: line-through;
+  text-decoration: line-through !important;
+}
+
+.u-textDecorationNone {
+  text-decoration: none !important;
+}
+
+@if $responsive == true {
+  @each $bp-name, $bp-value in $breakpoints {
+    @media (min-width: $bp-value) {
+
+      @each $name, $value in $fontSizes {
+       .u-#{$bp-name}-fontSize#{$name} {
+         font-size: #{$value} !important;
+       }
+      }
+
+      .u-#{$bp-name}-textCenter {
+        text-align: center !important;
+      }
+
+      .u-#{$bp-name}-textLeft {
+        text-align: left !important;
+      }
+
+      .u-#{$bp-name}-textRight {
+        text-align: right !important;
+      }
+
+      .u-#{$bp-name}-textUnderline {
+        text-decoration: underline !important;
+      }
+
+      .u-#{$bp-name}-textLineThrough {
+        text-decoration: line-through !important;
+      }
+
+      .u-#{$bp-name}-textDecorationNone {
+        text-decoration: none !important;
+      }
+
+      .u-#{$bp-name}-textNoWrap {
+        white-space: nowrap !important;
+      }
+
+      .u-#{$bp-name}-textEllipsis {
+        text-overflow: ellipsis !important;
+        overflow: hidden !important;
+      }
+
+      .u-#{$bp-name}-textNormal {
+        font-weight: $tu-base-fontWeight !important;
+      }
+
+      .u-#{$bp-name}-textSemiBold {
+        font-weight: $tu-semibold-fontWeight !important;
+      }
+
+      .u-#{$bp-name}-textBold {
+        font-weight: $tu-bold-fontWeight !important;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Changes:
- Update `Checkbox`
  - no markup changes
  - Remove inner box shadows for cleaner appearance
  - Change radio to standard circle-within-a-circle appearance and add animation
  - Add hover states and change focus state (colored border)
  - Use SVG for inner icons (check and lock)
  - Add `--large` modifier
  - Add `--pill` modifier for full-width, easily tappable radios
  - Add `--colorPrimary` modifier for standard TS Blue version that is also themed

![checkbox-updates](https://user-images.githubusercontent.com/9888467/58911465-75936880-86dd-11e9-8be3-9cafc4cf62ab.gif)

- Update `Input` and `SelectBox` to match above changes
  - Remove inner shadow
  - Change focus state to colored border (uses primary color)

![input-updates](https://user-images.githubusercontent.com/9888467/58911562-b5f2e680-86dd-11e9-80c6-76a68691a6a0.gif)

- Update `StepNav`
  - no markup changes
  - Add `--xsmall` modifier
  - Add support for numbers instead of SVG
  - Reorganize CSS to remove repetition of size properties so modifiers can easily be created and size relationships maintained

<img width="664" alt="Screen Shot 2019-06-04 at 3 31 37 PM" src="https://user-images.githubusercontent.com/9888467/58911642-eaff3900-86dd-11e9-88cf-0fffcb622749.png">
<img width="673" alt="Screen Shot 2019-06-04 at 3 31 51 PM" src="https://user-images.githubusercontent.com/9888467/58911643-eaff3900-86dd-11e9-9a98-1fb603278e64.png">


- Add max-width utilities that track to bp sizes
  - xs, sm, md, lg

- Add border radius utilities
  - responsive

- Add `u-spaceSidesAuto` for centering elements (`u-flexExpandSides` also does this but it's not as intuitive)

- Add assorted other utilities:
  - Position (relative and absolute)
  - Foreground and Background bg
  - u-overflowHidden
  - make all text utilities responsive

  