### PR TITLE
DES-56 - Add Modal CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [3.1.0] - 2019-09-09
+
+- https://github.com/teamsnap/teamsnap-ui/pull/154
+- https://github.com/teamsnap/teamsnap-ui/pull/155
+
+### Changed
+
+- `Added` CSS & HTML for modals
+- `Security` Refactored theme variables for direct import
+- `Added` Utilities more for colors and borders 
+
 ## [3.0.0] - 2019-09-04
+
+- https://github.com/teamsnap/teamsnap-ui/pull/130
+
+### Changed
 
 - `Added` support for TypeScript
 - `Security` fixes for downstream dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/components/Modal.scss
+++ b/src/css/components/Modal.scss
@@ -1,0 +1,169 @@
+// * Modal Style
+// *
+// * 1. Other options 'Panel'. The $Modal-style setting may be
+// set in a theme config to change the style modals on a per
+// project basis.
+// *
+// * ex: $Modal-style: 'Panel';
+
+$Modal-style: 'Standard' !default; // 1
+$Modal-bgColor: $cu-foreground !default;
+$Modal-overlayColor: $ts-black !default;
+$Modal-borderStyle: $su-small solid $cu-background !default;
+$Modal-animation: 300ms cubic-bezier(0.2, 0.8, 0.4, 1.0);
+
+$Modal-borderStyle--panel: $border-width-small solid $cu-divider !default;
+
+// * Modal Overlay
+// *
+// * 1. Position overlay so that it covers the viewport
+// * 2. Align modal content in the center of the viewport
+
+.Modal {
+  display: none;
+  position: fixed; // 1
+  top: 0px; // 1
+  bottom: 0px; // 1
+  left: 0px; // 1
+  right: 0px; // 1
+  background-color: rgba( $Modal-overlayColor, .5 );
+  z-index: 1000;
+  justify-content: center; // 2
+  align-items: center; // 2
+
+  &.is-open,
+  &.is-active {
+    display: flex; // 2
+  }
+
+  &.is-closing {
+    animation: overlayOut $Modal-animation forwards;
+  }
+
+}
+
+// * Modal content (the actual modal)
+// *
+// * 1. Make sure modal is never taller than viewport
+// * 2. Allow content to scroll if content is taller than viewport
+// * 3. Default to 100% for small screens
+// * 4. Default max width (this can be adjusted as necessary at the component level)
+
+.Modal-content {
+  max-height: 100vh; // 1
+  overflow-y: auto; // 2
+  width: 100%; // 3
+  max-width: 600px; // 4
+  background-color: $Modal-bgColor;
+  border-radius: $border-radius-large;
+  animation: modalIn $Modal-animation forwards;
+  box-shadow: $box-shadow-large;
+  border: $Modal-borderStyle;
+
+  @if $Modal-style == 'Panel' {
+    border: $Modal-borderStyle--panel;
+
+  } @else {
+    padding: $su-large;
+
+  }
+
+}
+
+.Modal-header {  
+
+  @if $Modal-style == 'Panel' {
+    padding: $su-medium;
+    border-bottom: $Modal-borderStyle--panel;
+
+  } @else {
+    text-align: center;
+    padding-bottom: $su-large;
+
+  }
+
+}
+
+.Modal-iconDismiss {
+  box-sizing: content-box;
+  color: $cu-divider;
+  position: absolute;
+  padding: $su-small;
+  height: $su-medium;
+  width: $su-medium;
+  top: 0;
+  right: 0;
+  cursor: pointer;
+
+  &:hover {
+    color: scaleColor($cu-divider, -2);
+  }
+  
+}
+
+.Modal-title {
+  padding: 0;
+  margin: 0;
+
+  @if $Modal-style == 'Panel' {
+    font-size: $tu-large-fontSize;
+    color: $cu-info;
+    font-family: $base-font-family;
+    font-weight: $tu-bold-fontWeight;
+
+  } @else {
+    font-size: $tu-xlarge-fontSize;
+    color: $cu-primary;
+    font-family: $tu-museo700-fontFamily;
+
+  }
+
+}
+
+.Modal-body {
+
+  @if $Modal-style == 'Panel' {
+    padding: $su-medium;
+
+  }
+
+}
+
+.Modal-footer {
+
+  @if $Modal-style == 'Panel' {
+    border-top: $Modal-borderStyle--panel;
+    padding: $su-medium;
+    text-align: right;
+
+  } @else {
+    margin-top: $su-xlarge;
+    text-align: center;
+
+  }
+  
+}
+
+.Modal-bgDismiss {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}
+
+@keyframes modalIn{
+  0% {
+    transform: scale(0.7);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes overlayOut{
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/src/css/components/index.scss
+++ b/src/css/components/index.scss
@@ -10,6 +10,7 @@
 @import "Input";
 @import "InputGroup";
 @import "Loader";
+@import "Modal";
 @import "Panel";
 @import "Popup";
 @import "Progress";

--- a/src/css/config/config.scss
+++ b/src/css/config/config.scss
@@ -201,9 +201,9 @@ $duration-short: 250ms;
 
 // * 7. Box Shadows
 
-$box-shadow-small:  0 0 2px rgba($cu-info, 0.15) !default;
-$box-shadow-medium: 0 0 4px rgba($cu-info, 0.15) !default;
-$box-shadow-large:  0 0 6px rgba($cu-info, 0.15) !default;
+$box-shadow-small:  0 0 scaleGrid(-2) rgba($cu-info, 0.15) !default;
+$box-shadow-medium: 0 0 scaleGrid(-1) rgba($cu-info, 0.25) !default;
+$box-shadow-large:  0 0  scaleGrid(1) rgba($cu-info, 0.35) !default;
 
 $inset-box-shadow-small:  1px 1px 1px rgba($cu-info, 0.15) inset !default;
 $inset-box-shadow-medium: 1px 1px 2px rgba($cu-info, 0.15) inset !default;

--- a/src/css/config/themes/league.scss
+++ b/src/css/config/themes/league.scss
@@ -20,3 +20,4 @@
 
 $cu-primary:  #13426E;
 $color-links: #3079b7;
+$Modal-style: 'Panel';

--- a/src/css/themes/league.scss
+++ b/src/css/themes/league.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load theme config
 
-@import "../config/index";
+@import "../config/themes/league";
 
 // * 2. Load app css with new theme settings
 


### PR DESCRIPTION
Adding html & css for modals. This should work with https://github.com/teamsnap/classic/blob/master/app/assets/javascripts/new-skin/ts-modal.js

<img width="1680" alt="Screen Shot 2019-09-05 at 3 56 20 PM" src="https://user-images.githubusercontent.com/1189536/64386247-d5a7ec80-cff5-11e9-985b-0e5e673d1db9.png">

also added some styling  variation which can be turned on in theme settings

<img width="1680" alt="Screen Shot 2019-09-05 at 3 56 38 PM" src="https://user-images.githubusercontent.com/1189536/64386262-d93b7380-cff5-11e9-82e6-81cc0514d8ea.png">

----

Note: this was being held off on to pair with the react component, but could be used in classic with the freemium test, and other areas. Also sounds like there might never be a react component for this since state might be managed in a number of different ways.
