### PR TITLE
cleanup on disabled selects, inputs, and variables

### DIFF
--- a/src/css/components/Input.scss
+++ b/src/css/components/Input.scss
@@ -15,15 +15,13 @@
 
 // * 1. Input Settings
 
-$form-input-height: $su-xlarge !default;
-$form-input-line-height: $su-xlarge - 2 !default;
-$form-input-bg-color: $cu-foreground--dark !default;
+// form inputs use global variables in the main config
 
 // * 2. Base Input
 
 .Input {
   cursor: text;
-  color: $cu-info;
+  color: $form-input-border-color;
   display: block;
   width: 100%;
   height: $form-input-height;
@@ -32,15 +30,16 @@ $form-input-bg-color: $cu-foreground--dark !default;
   box-sizing: border-box;
   box-shadow: none;
   background-color: $form-input-bg-color;
-  border: $border-width-small solid $cu-divider;
+  border: $border-width-small solid $form-input-border-color;
   border-radius: $border-radius-medium;
   font-family: inherit;
   font-size: $tu-base-fontSize;
   transition: all ease 0.2s;
 
   &:disabled {
-    background: $cu-middleground--dark;
-    color: $ts-grey;
+    background: $form-input-bg-color--disabled;
+    color: $form-input-text-color--disabled;
+    border-color: $form-input-border-color--disabled;
     cursor: not-allowed;
   }
 

--- a/src/css/components/SelectBox.scss
+++ b/src/css/components/SelectBox.scss
@@ -6,14 +6,22 @@
 // * 1. Select Box Settings
 // * 2. Select Box
 
+// TODO: update the dropdown icon to SVG
+
 //------------------------------------------------------------//
 
 // * 1. Select Box Settings
 
-$SelectBox-bg-color: $cu-foreground--dark !default;
-$SelectBox-text-color: $cu-info !default;
-$SelectBox-height: $su-xlarge !default;
-$SelectBox-indicator-width: scaleGrid(4);
+$SelectBox-height: $form-input-height !default;
+$SelectBox-indicator-width: $form-input-height;
+
+$SelectBox-bg-color: $form-input-bg-color !default;
+$SelectBox-text-color: $form-input-text-color !default;
+$SelectBox-border-color: $form-input-border-color !default;
+
+$SelectBox-bg-color--disabled: $form-input-bg-color--disabled !default;
+$SelectBox-text-color--disabled: $form-input-text-color--disabled !default;
+$SelectBox-border-color--disabled: $form-input-border-color--disabled !default;
 
 // * 2. Select Box
 
@@ -31,7 +39,7 @@ $SelectBox-indicator-width: scaleGrid(4);
     right: 0;
     margin: auto;
     width: $SelectBox-indicator-width;
-    color: scaleColor($cu-info, 6);
+    color: $cu-info--light;
     font-size: $tu-xsmall-fontSize;
     height: ( $SelectBox-height - $su-small );
     line-height: ( $SelectBox-height - $su-xsmall );
@@ -39,6 +47,11 @@ $SelectBox-indicator-width: scaleGrid(4);
     border-left: $border-width-small solid $cu-divider--light;
     pointer-events: none;
   }
+
+  &.is-disabled:after {
+    color: $SelectBox-border-color--disabled;
+  }
+
 }
 
 .SelectBox-options {
@@ -68,11 +81,19 @@ $SelectBox-indicator-width: scaleGrid(4);
     outline: none;
   }
 
+  &:invalid {
+    color: red !important;
+  }
+
+  // Disabled State
   &:disabled,
   &.is-disabled {
-    color: $cu-divider--light;
+    background-color: $SelectBox-bg-color--disabled;
+    color: $SelectBox-text-color--disabled;
+    border-color: $SelectBox-border-color--disabled;
     cursor: not-allowed;
   }
+
 }
 
 // * Deprecated - No longer have a JS dependency

--- a/src/css/components/SelectBox.scss
+++ b/src/css/components/SelectBox.scss
@@ -81,10 +81,6 @@ $SelectBox-border-color--disabled: $form-input-border-color--disabled !default;
     outline: none;
   }
 
-  &:invalid {
-    color: red !important;
-  }
-
   // Disabled State
   &:disabled,
   &.is-disabled {

--- a/src/css/config/config.scss
+++ b/src/css/config/config.scss
@@ -88,7 +88,7 @@ $cu-highlight--bg:   scaleColor($cu-highlight, 10) !default;
 
 // * 1.a Spot Colors (link, facebook, twitter, etc.)
 
-$color-facebook:                           #3B5998 !default;
+$color-facebook: #3B5998 !default;
 
 // * 2. Typography
 
@@ -151,7 +151,7 @@ $su-xxxsmall:   scaleGrid(-3) !default; // 1px
 $su-xxsmall:    scaleGrid(-2) !default; // 2px
 $su-xsmall:     scaleGrid(-1) !default; // 4px
 $su-small:       scaleGrid(1) !default; // 8px
-$su-medium:     scaleGrid(2) !default; // 16px
+$su-medium:      scaleGrid(2) !default; // 16px
 $su-large:       scaleGrid(3) !default; // 24px
 $su-xlarge:      scaleGrid(4) !default; // 32px
 $su-xxlarge:     scaleGrid(5) !default; // 40px
@@ -159,28 +159,28 @@ $su-xxlarge:     scaleGrid(5) !default; // 40px
 // * 4. Responsive
 
 $responsive: false !default;
-$breakpoint-xs: 480px;
-$breakpoint-sm: 768px;
-$breakpoint-md: 992px;
+$breakpoint-xs:  480px;
+$breakpoint-sm:  768px;
+$breakpoint-md:  992px;
 $breakpoint-lg: 1200px;
 
 $breakpoint-xxs-max: $breakpoint-xs - 1px;
-$breakpoint-xs-max: $breakpoint-sm - 1px;
-$breakpoint-sm-max: $breakpoint-md - 1px;
-$breakpoint-md-max: $breakpoint-lg - 1px;
+$breakpoint-xs-max:  $breakpoint-sm - 1px;
+$breakpoint-sm-max:  $breakpoint-md - 1px;
+$breakpoint-md-max:  $breakpoint-lg - 1px;
 
 $breakpoints: (
   'xs':  $breakpoint-xs,
   'sm':  $breakpoint-sm,
   'md':  $breakpoint-md,
-  'lg': $breakpoint-lg
+  'lg':  $breakpoint-lg
 );
 
 $max-breakpoints: (
-  'xxsMax':  $breakpoint-xxs-max,
-  'xsMax':  $breakpoint-xs-max,
-  'smMax':  $breakpoint-sm-max,
-  'mdMax':  $breakpoint-md-max
+  'xxsMax': $breakpoint-xxs-max,
+  'xsMax':   $breakpoint-xs-max,
+  'smMax':   $breakpoint-sm-max,
+  'mdMax':   $breakpoint-md-max
 );
 
 $site-container: 1300px;
@@ -208,3 +208,16 @@ $box-shadow-large:  0 0  scaleGrid(1) rgba($cu-info, 0.35) !default;
 $inset-box-shadow-small:  1px 1px 1px rgba($cu-info, 0.15) inset !default;
 $inset-box-shadow-medium: 1px 1px 2px rgba($cu-info, 0.15) inset !default;
 $inset-box-shadow-large:  1px 1px 3px rgba($cu-info, 0.15) inset !default;
+
+// * 8. Form Inputs
+
+$form-input-height:                           $su-xlarge !default;
+$form-input-line-height:                  $su-xlarge - 2 !default;
+
+$form-input-bg-color:                     $cu-foreground !default;
+$form-input-text-color:                         $cu-info !default;
+$form-input-border-color:                    $cu-divider !default;
+
+$form-input-bg-color--disabled:         $cu-middleground !default;
+$form-input-text-color--disabled:        $cu-info--light !default;
+$form-input-border-color--disabled:   $cu-divider--light !default;


### PR DESCRIPTION
part of this ticket https://teamsnap.atlassian.net/browse/TNL-1673

cleaning up the disabled inputs and selects to make values readable. Previously the value of an input was the same color as the placeholder text.

---

Inputs:

no text entered:
<img width="801" alt="Screen Shot 2019-10-03 at 2 47 51 PM" src="https://user-images.githubusercontent.com/1189536/66163169-ee9fbf80-e5ec-11e9-9e80-b423530dd816.png">

text entered:
<img width="808" alt="Screen Shot 2019-10-03 at 2 48 18 PM" src="https://user-images.githubusercontent.com/1189536/66163183-f3647380-e5ec-11e9-8ce6-0f4c8564cad4.png">

SelectBox:
<img width="804" alt="Screen Shot 2019-10-03 at 2 48 32 PM" src="https://user-images.githubusercontent.com/1189536/66163225-0b3bf780-e5ed-11e9-97bf-fe6fac1aeac6.png">

---

Updated to match some classic changes:
https://github.com/teamsnap/classic/pull/8860

<img width="845" alt="Screen Shot 2019-10-03 at 2 07 18 PM" src="https://user-images.githubusercontent.com/1189536/66163286-2ad32000-e5ed-11e9-82c6-72fb5b031983.png">

