### PR TITLE
Remove deprecated lifecycle method for prep for react 17

### DIFF
--- a/src/js/components/Table/Table.tsx
+++ b/src/js/components/Table/Table.tsx
@@ -83,40 +83,35 @@ class Table extends React.PureComponent<any, State> {
 
   constructor(props) {
     super(props);
-    const { rows, defaultSort } = this.props;
+    const { defaultSort } = this.props;
 
     // Establish initial sortDirection by checking for '-' value
     const sortDirection = defaultSort.charAt(0) === "-" ? true : false;
     const sortName = sortDirection ? defaultSort.substr(1) : defaultSort;
 
-    const state = this.getTableState(rows, sortName, sortDirection);
+    const state = Table.getTableState(props, sortName, sortDirection);
     this.state = { ...state };
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { sortByColumn, sortByReverse } = this.state;
+  static getDerivedStateFromProps(props, state) {
+    const { sortByColumn, sortByReverse } = state;
 
-    this.setTableState(nextProps.rows, sortByColumn, sortByReverse);
+    return Table.getTableState(props, sortByColumn, sortByReverse);
   }
 
-  private getTableState(rows, sortName, sortDirection) {
+  private static getTableState(props, sortName, sortDirection) {
+    const { rows } = props;
     const items = setUniqueId(rows);
 
     const tableState = sortName
-      ? this.sortItems(items, sortName, sortDirection)
+      ? Table.sortItems(props, items, sortName, sortDirection)
       : { items };
 
     return tableState;
   }
 
-  setTableState = (rows, sortName, sortDirection) => {
-    const tableState = this.getTableState(rows, sortName, sortDirection);
-
-    this.setState({ ...tableState });
-  };
-
-  sortItems = (newItems, sortByColumn, sortByReverse) => {
-    const { columns } = this.props;
+  static sortItems = (props, newItems, sortByColumn, sortByReverse) => {
+    const { columns } = props;
 
     const { name, sortType, sortFn } = columns.find(
       c => c.name === sortByColumn
@@ -138,7 +133,12 @@ class Table extends React.PureComponent<any, State> {
 
     const sortDirection =
       sortName === this.state.sortByColumn ? !this.state.sortByReverse : false;
-    const tableState = this.sortItems(items, sortName, sortDirection);
+    const tableState = Table.sortItems(
+      this.props,
+      items,
+      sortName,
+      sortDirection
+    );
 
     this.setState({ ...tableState });
   };

--- a/src/js/components/Table/Table.tsx
+++ b/src/js/components/Table/Table.tsx
@@ -33,7 +33,13 @@ import { PanelCell } from "../PanelCell";
 import { TextLink } from "../TextLink";
 import { Loader } from "../Loader";
 
-class Table extends React.PureComponent<any, any> {
+interface State {
+  items: any[];
+  sortByColumn?: any;
+  sortByReverse?: any;
+}
+
+class Table extends React.PureComponent<any, State> {
   static defaultProps = {
     columns: [],
     rows: [],
@@ -75,20 +81,16 @@ class Table extends React.PureComponent<any, any> {
     placeHolder: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
   };
 
-  state = {
-    items: [],
-    sortByColumn: "",
-    sortByReverse: false
-  };
-
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     const { rows, defaultSort } = this.props;
 
     // Establish initial sortDirection by checking for '-' value
     const sortDirection = defaultSort.charAt(0) === "-" ? true : false;
     const sortName = sortDirection ? defaultSort.substr(1) : defaultSort;
 
-    this.setTableState(rows, sortName, sortDirection);
+    const state = this.getTableState(rows, sortName, sortDirection);
+    this.state = { ...state };
   }
 
   componentWillReceiveProps(nextProps) {
@@ -97,12 +99,18 @@ class Table extends React.PureComponent<any, any> {
     this.setTableState(nextProps.rows, sortByColumn, sortByReverse);
   }
 
-  setTableState = (rows, sortName, sortDirection) => {
+  private getTableState(rows, sortName, sortDirection) {
     const items = setUniqueId(rows);
 
     const tableState = sortName
       ? this.sortItems(items, sortName, sortDirection)
       : { items };
+
+    return tableState;
+  }
+
+  setTableState = (rows, sortName, sortDirection) => {
+    const tableState = this.getTableState(rows, sortName, sortDirection);
 
     this.setState({ ...tableState });
   };


### PR DESCRIPTION
Trying to get TeamSnap UI ready for React 17+.

I think this is the only component with deprecated lifecycle methods. ![](https://media3.giphy.com/media/JMV7IKoqzxlrW/giphy.webp?cid=790b76113a7fd8c3480e2d61e58c79e969eca3d9703472b8&rid=giphy.webp)

So this PR removes those lifecycle methods in favor of the alternatives proposed in https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props