### PR TITLE
fix import path for config index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7223,8 +7223,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7248,15 +7247,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7273,22 +7270,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7419,8 +7413,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7434,7 +7427,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7451,7 +7443,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7460,15 +7451,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7489,7 +7478,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7578,8 +7566,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7593,7 +7580,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7689,8 +7675,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7732,7 +7717,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7754,7 +7738,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7803,15 +7786,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/css/config/themes/blue-steel.scss
+++ b/src/css/config/themes/blue-steel.scss
@@ -12,7 +12,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/care-bear.scss
+++ b/src/css/config/themes/care-bear.scss
@@ -12,7 +12,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/christmas-sweater.scss
+++ b/src/css/config/themes/christmas-sweater.scss
@@ -20,7 +20,7 @@
 
 //--------------------------------------------------------------//
 
-@import "../config/index";
+@import "../index";
 
 // * 1. Redefine Color Variables for Theme
 

--- a/src/css/config/themes/custom-aquablue.scss
+++ b/src/css/config/themes/custom-aquablue.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-black.scss
+++ b/src/css/config/themes/custom-black.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-blue.scss
+++ b/src/css/config/themes/custom-blue.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-darkblue.scss
+++ b/src/css/config/themes/custom-darkblue.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-darkgreen.scss
+++ b/src/css/config/themes/custom-darkgreen.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-darkred.scss
+++ b/src/css/config/themes/custom-darkred.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-goldenyellow.scss
+++ b/src/css/config/themes/custom-goldenyellow.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-gray.scss
+++ b/src/css/config/themes/custom-gray.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-green.scss
+++ b/src/css/config/themes/custom-green.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-leafgreen.scss
+++ b/src/css/config/themes/custom-leafgreen.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-lemonyellow.scss
+++ b/src/css/config/themes/custom-lemonyellow.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-lightblue.scss
+++ b/src/css/config/themes/custom-lightblue.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-orange.scss
+++ b/src/css/config/themes/custom-orange.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-pink.scss
+++ b/src/css/config/themes/custom-pink.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-purple.scss
+++ b/src/css/config/themes/custom-purple.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/custom-red.scss
+++ b/src/css/config/themes/custom-red.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/league.scss
+++ b/src/css/config/themes/league.scss
@@ -14,7 +14,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/maple-leaf.scss
+++ b/src/css/config/themes/maple-leaf.scss
@@ -13,7 +13,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/portland-oregon.scss
+++ b/src/css/config/themes/portland-oregon.scss
@@ -12,7 +12,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/ranger-smith.scss
+++ b/src/css/config/themes/ranger-smith.scss
@@ -12,7 +12,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 

--- a/src/css/config/themes/up-beet.scss
+++ b/src/css/config/themes/up-beet.scss
@@ -12,7 +12,7 @@
 
 // * 1. Load functions, mixins, & default variables
 
-@import "../config/index";
+@import "../index";
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 


### PR DESCRIPTION
This change is required to resolve an indirect pathing problem I ran into while trying to utilize the league them in organization-frontend. The theme in question was attempting to import `../config/index` which took us one level too far out of the file tree structure and therefore it was unable to resolve the path. Upon further investigation, it was discovered this path was actually incorrect for every theme in the config directory.