### PR TITLE
Infer typescript types from prop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [3.3.0] - 2019-12-05
+- https://github.com/teamsnap/teamsnap-ui/pull/208
+- https://github.com/teamsnap/teamsnap-ui/pull/206
+
+### Fixed
+- `Fixed` A bug that prevented theme configs for loading properly.
+
+### Added
+- `Added` Support for TypeScript props via `PropTypes.InferProps`
+
 ## [3.2.2] - 2019-12-04
 - https://github.com/teamsnap/teamsnap-ui/pull/204
 

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  teamsnap-ui:
+    build:
+      context: .
+      dockerfile: docker/codeship.dockerfile
+    cached: true

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,0 +1,6 @@
+
+- type: parallel
+steps:
+  - name: build
+    service: teamsnap-ui
+    command: npm run build

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,4 +1,3 @@
-
 - type: parallel
 steps:
   - name: build

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,5 +1,5 @@
 - type: parallel
-steps:
+  steps:
   - name: build
     service: teamsnap-ui
     command: npm run build

--- a/docker/codeship.dockerfile
+++ b/docker/codeship.dockerfile
@@ -1,0 +1,11 @@
+## This is intended to be ran by codeship's compose setup.
+
+FROM node:10.16.0-alpine
+
+WORKDIR /usr/app
+COPY package.json .
+COPY yarn.lock .
+COPY src/core/test_environment.ts /usr/app/src/core/environment.ts
+RUN yarn install
+
+COPY . .

--- a/docker/codeship.dockerfile
+++ b/docker/codeship.dockerfile
@@ -4,8 +4,7 @@ FROM node:10.16.0-alpine
 
 WORKDIR /usr/app
 COPY package.json .
-COPY yarn.lock .
-COPY src/core/test_environment.ts /usr/app/src/core/environment.ts
-RUN yarn install
+COPY package-lock.json .
+RUN npm install
 
 COPY . .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Button/Button.tsx
+++ b/src/js/components/Button/Button.tsx
@@ -23,7 +23,7 @@ import { Icon } from "../Icon";
 import { TextLink } from "../TextLink";
 import { getClassName } from "../../utils/helpers";
 
-class Button extends React.PureComponent<any, any> {
+class Button extends React.PureComponent<PropTypes.InferProps<typeof Button.propTypes>, any> {
   static propTypes = {
     type: PropTypes.oneOf(["button", "submit", "link"]),
     label: PropTypes.string,
@@ -92,7 +92,6 @@ class Button extends React.PureComponent<any, any> {
     const {
       routerLink,
       location,
-      isDisabled,
       onClick,
       style,
       otherProps
@@ -104,7 +103,6 @@ class Button extends React.PureComponent<any, any> {
         routerLink={routerLink}
         location={location}
         style={style}
-        disabled={isDisabled}
         onClick={onClick}
         {...otherProps}
       >
@@ -118,7 +116,7 @@ class Button extends React.PureComponent<any, any> {
 
     return (
       <button
-        type={type}
+        type={(type as "button" | "reset")}
         className={this.getButtonClassName()}
         style={style}
         onClick={onClick}

--- a/src/js/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/js/components/ButtonGroup/ButtonGroup.tsx
@@ -19,7 +19,7 @@ import * as PropTypes from "prop-types";
 import { Button } from "../Button";
 import { getClassName } from "../../utils/helpers";
 
-class ButtonGroup extends React.PureComponent<any, any> {
+class ButtonGroup extends React.PureComponent<PropTypes.InferProps<typeof ButtonGroup.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node,
     buttons: PropTypes.array,

--- a/src/js/components/Cell/Cell.tsx
+++ b/src/js/components/Cell/Cell.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class Cell extends React.PureComponent<any, any> {
+class Cell extends React.PureComponent<PropTypes.InferProps<typeof Cell.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,

--- a/src/js/components/Checkbox/Checkbox.tsx
+++ b/src/js/components/Checkbox/Checkbox.tsx
@@ -15,7 +15,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { InputControl } from "../InputControl";
 
-class Checkbox extends React.PureComponent<any, any> {
+class Checkbox extends React.PureComponent<PropTypes.InferProps<typeof Checkbox.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     label: PropTypes.node.isRequired,

--- a/src/js/components/Divider/Divider.tsx
+++ b/src/js/components/Divider/Divider.tsx
@@ -14,17 +14,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-interface Props {
-  isIndented: boolean;
-  isSpaced: boolean;
-  isThick: boolean;
-  className: string;
-  mods: string;
-  style: any;
-  otherProps: any;
-}
-
-class Divider extends React.PureComponent<Props, any> {
+class Divider extends React.PureComponent<PropTypes.InferProps<typeof Divider.propTypes>, any> {
   static propTypes = {
     isIndented: PropTypes.bool,
     isSpaced: PropTypes.bool,

--- a/src/js/components/FieldGroup/FieldGroup.stories.tsx
+++ b/src/js/components/FieldGroup/FieldGroup.stories.tsx
@@ -28,7 +28,7 @@ stories.add("FieldGroup with Input text child", () => {
   const status = select("status", statusOptions);
 
   return (
-    <FieldGroup name="example" label="Check Me" isInline status={status}>
+    <FieldGroup status={status}>
       <FieldLabel name="example">Text Input</FieldLabel>
       <Input name="storybook" type="text" />
       {status === "error" ? (
@@ -43,7 +43,7 @@ stories.add("FieldGroup with Select child", () => {
   const status = select("status", statusOptions);
 
   return (
-    <FieldGroup name="example" label="Check Me" isInline status={status}>
+    <FieldGroup status={status}>
       <FieldLabel name="example">Select Box</FieldLabel>
       <Select
         name="LineItemFeeCategory"
@@ -71,7 +71,7 @@ stories.add("FieldGroup with Input text and Icon children", () => {
   const iconPosition = select("iconPosition", iconOptions);
 
   return (
-    <FieldGroup name="example" label="Check Me" status={status}>
+    <FieldGroup status={status}>
       <FieldLabel name="example">Location Input</FieldLabel>
       <Input name="storybook" type="text" iconPosition={iconPosition || "left"}>
         <Icon name="location" />
@@ -88,7 +88,7 @@ stories.add("FieldGroup with Checkbox children", () => {
   const status = select("status", statusOptions);
 
   return (
-    <FieldGroup name="example" label="Check Me" status={status}>
+    <FieldGroup status={status}>
       <FieldLabel name="example">Select all that apply:</FieldLabel>
       <Checkbox name="example" label="Check Me" isInline />
       <Checkbox name="example2" label="Check Me 2" isInline />

--- a/src/js/components/FieldGroup/FieldGroup.tsx
+++ b/src/js/components/FieldGroup/FieldGroup.tsx
@@ -17,7 +17,7 @@ import * as PropTypes from "prop-types";
 import { Icon } from "../Icon";
 import { getClassName } from "../../utils/helpers";
 
-class FieldGroup extends React.PureComponent<any, any> {
+class FieldGroup extends React.PureComponent<PropTypes.InferProps<typeof FieldGroup.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     status: PropTypes.oneOf([null, "success", "error"]),

--- a/src/js/components/FieldLabel/FieldLabel.tsx
+++ b/src/js/components/FieldLabel/FieldLabel.tsx
@@ -14,7 +14,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class FieldLabel extends React.PureComponent<any, any> {
+class FieldLabel extends React.PureComponent<PropTypes.InferProps<typeof FieldLabel.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     name: PropTypes.string,

--- a/src/js/components/FieldMessage/FieldMessage.tsx
+++ b/src/js/components/FieldMessage/FieldMessage.tsx
@@ -14,7 +14,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class FieldMessage extends React.PureComponent<any, any> {
+class FieldMessage extends React.PureComponent<PropTypes.InferProps<typeof FieldMessage.propTypes>, any> {
   static propTypes = {
     children: PropTypes.string,
     isError: PropTypes.bool,

--- a/src/js/components/FieldWrapper/FieldWrapper.tsx
+++ b/src/js/components/FieldWrapper/FieldWrapper.tsx
@@ -27,7 +27,7 @@ import { Radio } from "../Radio";
 import { Toggle } from "../Toggle";
 import { Select } from "../Select";
 
-class FieldWrapper extends React.PureComponent<any, any> {
+class FieldWrapper extends React.PureComponent<PropTypes.InferProps<typeof FieldWrapper.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     field: PropTypes.oneOf([
@@ -38,7 +38,7 @@ class FieldWrapper extends React.PureComponent<any, any> {
       "select",
       "textarea"
     ]).isRequired,
-    fieldProps: PropTypes.object,
+    fieldProps: PropTypes.any,
     status: PropTypes.oneOf([null, "success", "error"]),
     label: PropTypes.node,
     message: PropTypes.string

--- a/src/js/components/Grid/Grid.tsx
+++ b/src/js/components/Grid/Grid.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class Grid extends React.PureComponent<any, any> {
+class Grid extends React.PureComponent<PropTypes.InferProps<typeof Grid.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     isFit: PropTypes.bool,

--- a/src/js/components/Icon/Icon.tsx
+++ b/src/js/components/Icon/Icon.tsx
@@ -18,15 +18,7 @@ import { getClassName } from "../../utils/helpers";
 
 const svgIcon = name => require(`../../icons/${name}`);
 
-interface Props {
-  name: string;
-  className?: string;
-  mods?: string;
-  style?: any;
-  otherProps?: any;
-}
-
-class Icon extends React.PureComponent<Props, any> {
+class Icon extends React.PureComponent<PropTypes.InferProps<typeof Icon.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     className: PropTypes.string,

--- a/src/js/components/Input/Input.tsx
+++ b/src/js/components/Input/Input.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class Input extends React.PureComponent<any, any> {
+class Input extends React.PureComponent<PropTypes.InferProps<typeof Input.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     type: PropTypes.string,

--- a/src/js/components/InputControl/InputControl.tsx
+++ b/src/js/components/InputControl/InputControl.tsx
@@ -14,21 +14,8 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-interface Props {
-  name?: string;
-  type: string;
-  label?: React.ReactNode;
-  group?: string;
-  inputProps?: React.Props<any>;
-  labelProps?: React.Props<any>;
-  isInline?: boolean;
-  className?: string;
-  mods?: string;
-  style?: any;
-  otherProps?: any;
-}
 
-class InputControl extends React.PureComponent<Props, any> {
+class InputControl extends React.PureComponent<PropTypes.InferProps<typeof InputControl.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,

--- a/src/js/components/Loader/Loader.tsx
+++ b/src/js/components/Loader/Loader.tsx
@@ -14,21 +14,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-// TODO: Can we just use this instead of PropTypes?
-// A: Not until we export the type definitions as well.
-// If a consumer is not using typescript, they'll lose the type-assist if we just use the interface and not
-// the prop-types library. Need to investigate this so we dont have to maintain this list twice.
-interface Props {
-  type: "jello" | "pulse" | "spin";
-  text?: string;
-  message?: string;
-  className?: string;
-  mods?: string;
-  style?: any;
-  otherProps?: any;
-}
-
-class Loader extends React.PureComponent<Props, any> {
+class Loader extends React.PureComponent<PropTypes.InferProps<typeof Loader.propTypes>, any> {
   static propTypes = {
     type: PropTypes.oneOf(["jello", "pulse", "spin"]).isRequired,
     text: PropTypes.string,

--- a/src/js/components/Panel/Panel.tsx
+++ b/src/js/components/Panel/Panel.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class Panel extends React.PureComponent<any, any> {
+class Panel extends React.PureComponent<PropTypes.InferProps<typeof Panel.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     isStriped: PropTypes.bool,

--- a/src/js/components/PanelBody/PanelBody.tsx
+++ b/src/js/components/PanelBody/PanelBody.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class PanelBody extends React.PureComponent<any, any> {
+class PanelBody extends React.PureComponent<PropTypes.InferProps<typeof PanelBody.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,

--- a/src/js/components/PanelCell/PanelCell.tsx
+++ b/src/js/components/PanelCell/PanelCell.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class PanelCell extends React.PureComponent<any, any> {
+class PanelCell extends React.PureComponent<PropTypes.InferProps<typeof PanelCell.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node,
     isTitle: PropTypes.bool,
@@ -24,7 +24,7 @@ class PanelCell extends React.PureComponent<any, any> {
     className: PropTypes.string,
     mods: PropTypes.string,
     style: PropTypes.object,
-    otherProps: PropTypes.object
+    otherProps: PropTypes.object,
   };
 
   static defaultProps = {

--- a/src/js/components/PanelFooter/PanelFooter.tsx
+++ b/src/js/components/PanelFooter/PanelFooter.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class PanelFooter extends React.PureComponent<any, any> {
+class PanelFooter extends React.PureComponent<PropTypes.InferProps<typeof PanelFooter.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,

--- a/src/js/components/PanelHeader/PanelHeader.tsx
+++ b/src/js/components/PanelHeader/PanelHeader.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class PanelHeader extends React.PureComponent<any, any> {
+class PanelHeader extends React.PureComponent<PropTypes.InferProps<typeof PanelHeader.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node,
     title: PropTypes.string,
@@ -25,7 +25,7 @@ class PanelHeader extends React.PureComponent<any, any> {
     style: PropTypes.shape({}),
     headerImage: PropTypes.shape({
       Source: PropTypes.string,
-      PlaceHolder: PropTypes.string
+      Placeholder: PropTypes.string
     }),
     otherProps: PropTypes.shape({})
   };

--- a/src/js/components/PanelRow/PanelRow.tsx
+++ b/src/js/components/PanelRow/PanelRow.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class PanelRow extends React.PureComponent<any, any> {
+class PanelRow extends React.PureComponent<PropTypes.InferProps<typeof PanelRow.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     isWithCells: PropTypes.bool,

--- a/src/js/components/PanelRowExpandable/PanelRowExpandable.tsx
+++ b/src/js/components/PanelRowExpandable/PanelRowExpandable.tsx
@@ -23,7 +23,7 @@ import { PanelCell } from "../PanelCell";
 import { Icon } from "../Icon";
 import { getClassName } from "../../utils/helpers";
 
-class PanelRowExpandable extends React.PureComponent<any, any> {
+class PanelRowExpandable extends React.PureComponent<PropTypes.InferProps<typeof PanelRowExpandable.propTypes>, any> {
   static propTypes = {
     parentColumns: PropTypes.arrayOf(PropTypes.object).isRequired,
     childColumns: PropTypes.arrayOf(PropTypes.object),
@@ -86,10 +86,10 @@ class PanelRowExpandable extends React.PureComponent<any, any> {
       return renderColumn ? (
         renderColumn({ key: index, children, ...props })
       ) : (
-        <PanelCell key={index} {...props}>
-          {children}
-        </PanelCell>
-      );
+          <PanelCell key={index} {...props}>
+            {children}
+          </PanelCell>
+        );
     });
   };
 

--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { select } from "@storybook/addon-knobs/react";
-import PopupAction, { Action } from "./PopupAction";
+import PopupAction from "./PopupAction";
 import PopupConfirm from "./PopupConfirm";
 
 const stories = storiesOf("Popup", module);
 
-const actions: Array<Action> = [
+const actions = [
   {
     text: "Log to console",
     callback: () => {

--- a/src/js/components/Popup/PopupAction.tsx
+++ b/src/js/components/Popup/PopupAction.tsx
@@ -1,38 +1,32 @@
 import * as React from "react";
+import * as PropTypes from "prop-types";
+
 
 interface State {
   isPopupOpen: boolean;
   isConfirmOpen: boolean;
-  selectedAction: Action;
+  selectedAction: any;
 }
 
-export interface Action {
-  text: string;
-  callback: () => void;
-  requiresConfirmation?: boolean;
-  confirmationText?: string | React.ReactElement;
-}
+export default class PopUpAction extends React.Component<PropTypes.InferProps<typeof PopUpAction.propTypes>, State> {
+  static propTypes = {
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    actions: PropTypes.arrayOf(PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      callback: PropTypes.func.isRequired,
+      requiresConfirmation: PropTypes.bool,
+      confirmationText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    })),
+    popupStyle: PropTypes.object,
+    direction: PropTypes.arrayOf(PropTypes.oneOf(["down", "right", "left", "rightHang", "leftHang", "overlay"])),
+  };
 
-interface Props {
-  text: string | React.ReactElement;
-  actions: Array<Action>;
-  popupStyle?: React.CSSProperties;
-  direction?: (
-    | "down"
-    | "right"
-    | "left"
-    | "rightHang"
-    | "leftHang"
-    | "overlay")[];
-}
-
-export default class PopUpAction extends React.Component<Props, State> {
-  constructor(props: Props) {
+  constructor(props) {
     super(props);
     this.state = {
       isPopupOpen: false,
       isConfirmOpen: false,
-      selectedAction: {} as Action
+      selectedAction: {}
     };
   }
 
@@ -58,7 +52,7 @@ export default class PopUpAction extends React.Component<Props, State> {
     });
   }
 
-  handleActionClick(action: Action) {
+  handleActionClick(action) {
     if (action.requiresConfirmation) {
       this.setState({
         ...this.state,
@@ -120,7 +114,7 @@ export default class PopUpAction extends React.Component<Props, State> {
             className={
               "Popup-container Popup-container--overlay" +
               (this.state.selectedAction.requiresConfirmation &&
-              this.state.isConfirmOpen
+                this.state.isConfirmOpen
                 ? " is-open"
                 : "")
             }
@@ -136,7 +130,7 @@ export default class PopUpAction extends React.Component<Props, State> {
                     this.setState({
                       ...this.state,
                       isConfirmOpen: false,
-                      selectedAction: {} as Action
+                      selectedAction: {}
                     })
                   }
                   className="u-spaceRightSm Button Button--negative"

--- a/src/js/components/Popup/PopupConfirm.tsx
+++ b/src/js/components/Popup/PopupConfirm.tsx
@@ -1,19 +1,21 @@
 import * as React from "react";
+import * as PropTypes from "prop-types";
+
 
 interface State {
   isPopupOpen: boolean;
 }
 
-interface Props {
-  buttonText: string | React.ReactElement;
-  popUpText: string | React.ReactElement;
-  popupStyle?: React.CSSProperties;
-  onAccept: () => void;
-  onCancel?: () => void;
-}
+export default class Popup extends React.Component<PropTypes.InferProps<typeof Popup.propTypes>, State> {
+  static propTypes = {
+    buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
+    popUpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    popupStyle: PropTypes.object,
+    onAccept: PropTypes.func.isRequired,
+    onCancel: PropTypes.func,
+  };
 
-export default class Popup extends React.Component<Props, State> {
-  constructor(props: Props) {
+  constructor(props) {
     super(props);
     this.state = {
       isPopupOpen: false

--- a/src/js/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/js/components/ProgressBar/ProgressBar.stories.tsx
@@ -13,7 +13,7 @@ const sizeOptions = {
   xlarge: "xlarge"
 };
 
-stories.add("Default", () => <ProgressBar isInline progress={33} />);
+stories.add("Default", () => <ProgressBar progress={33} />);
 
 stories.add(
   "Vertical Bars",
@@ -70,13 +70,13 @@ stories.add(
     return (
       <div>
         <h4>Neutral</h4>
-        <ProgressBar isInline progress={33} color="neutral" size={size} />
+        <ProgressBar progress={33} color="neutral" size={size} />
         <br />
         <h4>Negative</h4>
-        <ProgressBar isInline progress={66} color="negative" size={size} />
+        <ProgressBar progress={66} color="negative" size={size} />
         <br />
         <h4>Default Color</h4>
-        <ProgressBar isInline progress={100} size={size} />
+        <ProgressBar progress={100} size={size} />
         <br />
       </div>
     );

--- a/src/js/components/ProgressBar/ProgressBar.tsx
+++ b/src/js/components/ProgressBar/ProgressBar.tsx
@@ -7,7 +7,6 @@
  *
  * @example
  * <ProgressBar
- *   isInline
  *   title='Percentage Paid'
  *   type='negative'
  *   size='small'
@@ -19,7 +18,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class ProgressBar extends React.PureComponent<any, any> {
+class ProgressBar extends React.PureComponent<PropTypes.InferProps<typeof ProgressBar.propTypes>, any> {
   static propTypes = {
     progress: PropTypes.number,
     size: PropTypes.string,

--- a/src/js/components/RadialProgress/RadialProgress.stories.tsx
+++ b/src/js/components/RadialProgress/RadialProgress.stories.tsx
@@ -13,7 +13,7 @@ const sizeOptions = {
   xlarge: "xlarge"
 };
 
-stories.add("Default", () => <RadialProgress isInline progress={33} />);
+stories.add("Default", () => <RadialProgress progress={33} />);
 
 stories.add(
   "Progress Colors",
@@ -23,13 +23,13 @@ stories.add(
     return (
       <div>
         <h4>Neutral</h4>
-        <RadialProgress isInline progress={33} color="neutral" size={size} />
+        <RadialProgress progress={33} color="neutral" size={size} />
         <br />
         <h4>Negative</h4>
-        <RadialProgress isInline progress={66} color="negative" size={size} />
+        <RadialProgress progress={66} color="negative" size={size} />
         <br />
         <h4>Default Color</h4>
-        <RadialProgress isInline progress={100} size={size} />
+        <RadialProgress progress={100} size={size} />
         <br />
       </div>
     );

--- a/src/js/components/RadialProgress/RadialProgress.tsx
+++ b/src/js/components/RadialProgress/RadialProgress.tsx
@@ -9,7 +9,7 @@ interface Circle {
   className?: string;
 }
 
-class RadialProgress extends React.PureComponent<any, any> {
+class RadialProgress extends React.PureComponent<PropTypes.InferProps<typeof RadialProgress.propTypes>, any> {
   static propTypes = {
     progress: PropTypes.number,
     size: PropTypes.string,

--- a/src/js/components/Radio/Radio.tsx
+++ b/src/js/components/Radio/Radio.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { InputControl } from "../InputControl";
 
-class Radio extends React.PureComponent<any, any> {
+class Radio extends React.PureComponent<PropTypes.InferProps<typeof Radio.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     label: PropTypes.node.isRequired,

--- a/src/js/components/Select/Select.tsx
+++ b/src/js/components/Select/Select.tsx
@@ -26,7 +26,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class Select extends React.PureComponent<any, any> {
+class Select extends React.PureComponent<PropTypes.InferProps<typeof Select.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     options: PropTypes.arrayOf(
@@ -40,7 +40,8 @@ class Select extends React.PureComponent<any, any> {
     className: PropTypes.string,
     mods: PropTypes.string,
     style: PropTypes.object,
-    otherProps: PropTypes.object
+    otherProps: PropTypes.object,
+    disabled: PropTypes.bool
   };
 
   static defaultProps = {
@@ -69,7 +70,8 @@ class Select extends React.PureComponent<any, any> {
       className,
       mods,
       style,
-      otherProps
+      otherProps,
+      disabled
     } = this.props;
 
     return (
@@ -82,6 +84,7 @@ class Select extends React.PureComponent<any, any> {
           className="SelectBox-options"
           name={name}
           id={name}
+          disabled={disabled}
           {...inputProps}
         >
           {options.map(this.renderOptions)}

--- a/src/js/components/StepNav/StepNav.tsx
+++ b/src/js/components/StepNav/StepNav.tsx
@@ -22,7 +22,7 @@ import { Icon } from "../Icon";
 import { TextLink } from "../TextLink";
 import { getClassName } from "../../utils/helpers";
 
-class StepNav extends React.PureComponent<any, any> {
+class StepNav extends React.PureComponent<PropTypes.InferProps<typeof StepNav.propTypes>, any> {
   static propTypes = {
     steps: PropTypes.arrayOf(
       PropTypes.shape({
@@ -59,7 +59,8 @@ class StepNav extends React.PureComponent<any, any> {
     );
   };
 
-  renderStep = ({ name, icon, isActive, linkProps }) => {
+  renderStep = (step) => {
+    const { name, icon, isActive, linkProps } = step;
     const stepClasses = getClassName(
       "StepNav-step",
       linkProps && "is-enabled",

--- a/src/js/components/SummaryList/SummaryList.tsx
+++ b/src/js/components/SummaryList/SummaryList.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class SummaryList extends React.PureComponent<any, any> {
+class SummaryList extends React.PureComponent<PropTypes.InferProps<typeof SummaryList.propTypes>, any> {
   static propTypes = {
     items: PropTypes.arrayOf(
       PropTypes.shape({
@@ -32,7 +32,10 @@ class SummaryList extends React.PureComponent<any, any> {
     ).isRequired,
     heading: PropTypes.string,
     subHeading: PropTypes.string,
-    footer: PropTypes.object,
+    footer: PropTypes.shape({
+      description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+    }),
     className: PropTypes.string,
     mods: PropTypes.string,
     style: PropTypes.object,

--- a/src/js/components/Table/Table.tsx
+++ b/src/js/components/Table/Table.tsx
@@ -39,7 +39,7 @@ interface State {
   sortByReverse?: any;
 }
 
-class Table extends React.PureComponent<any, State> {
+class Table extends React.PureComponent<PropTypes.InferProps<typeof Table.propTypes>, State> {
   static defaultProps = {
     columns: [],
     rows: [],

--- a/src/js/components/TextArea/TextArea.tsx
+++ b/src/js/components/TextArea/TextArea.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class TextArea extends React.PureComponent<any, any> {
+class TextArea extends React.PureComponent<PropTypes.InferProps<typeof TextArea.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     inputProps: PropTypes.object,

--- a/src/js/components/TextLink/TextLink.tsx
+++ b/src/js/components/TextLink/TextLink.tsx
@@ -17,13 +17,12 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class TextLink extends React.PureComponent<any, any> {
+class TextLink extends React.PureComponent<PropTypes.InferProps<typeof TextLink.propTypes>, any> {
   static propTypes = {
     children: PropTypes.node.isRequired,
     routerLink: PropTypes.func,
     location: PropTypes.string,
     onClick: PropTypes.func,
-    disabled: PropTypes.bool,
     className: PropTypes.string,
     mods: PropTypes.string,
     style: PropTypes.object,
@@ -34,7 +33,6 @@ class TextLink extends React.PureComponent<any, any> {
     routerLink: null,
     location: "",
     onClick: null,
-    disabled: false,
     className: "",
     mods: null,
     style: {},
@@ -47,7 +45,6 @@ class TextLink extends React.PureComponent<any, any> {
       location,
       routerLink,
       onClick,
-      disabled,
       className,
       mods,
       style,
@@ -65,7 +62,6 @@ class TextLink extends React.PureComponent<any, any> {
         className={getClassName(className, mods)}
         style={style}
         onClick={onClick}
-        disabled={disabled}
         {...linkType}
         {...otherProps}
       >

--- a/src/js/components/Toggle/Toggle.tsx
+++ b/src/js/components/Toggle/Toggle.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { InputControl } from "../InputControl";
 
-class Toggle extends React.PureComponent<any, any> {
+class Toggle extends React.PureComponent<PropTypes.InferProps<typeof Toggle.propTypes>, any> {
   static propTypes = {
     name: PropTypes.string.isRequired,
     inputProps: PropTypes.object,

--- a/src/js/components/Tooltip/Tooltip.tsx
+++ b/src/js/components/Tooltip/Tooltip.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { getClassName } from "../../utils/helpers";
 
-class Tooltip extends React.PureComponent<any, any> {
+class Tooltip extends React.PureComponent<PropTypes.InferProps<typeof Tooltip.propTypes>, any> {
   static propTypes = {
     text: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,

--- a/src/js/utils/helpers.ts
+++ b/src/js/utils/helpers.ts
@@ -5,8 +5,8 @@ import _capitalize from 'lodash/capitalize'
  * @name capitalize
  *
  * @description
- *  This simple method returns a string representing a uniqueID.
- *  Currently it is a 'wrapper' around the lodash uniqueId method.
+ *  This simple method returns a capitalized version of the provided string.
+ *  Currently it is a 'wrapper' around the lodash _capitalize method.
  *  There are other utilities we can look into as well, such as `shortid`
  *
  * @example
@@ -15,7 +15,7 @@ import _capitalize from 'lodash/capitalize'
  *  capitalize('name')
  *
  */
-export const capitalize = (string) => _capitalize(string)
+export const capitalize: (string: string) => string = (string) => _capitalize(string)
 
 /**
  * @name generateUniqueId
@@ -31,7 +31,7 @@ export const capitalize = (string) => _capitalize(string)
  *  generateUniqueId()
  *
  */
-export const generateUniqueId = (prefix='') => _uniqueId(prefix)
+export const generateUniqueId = (prefix = '') => _uniqueId(prefix)
 
 /**
  * @name setUniqueId
@@ -46,7 +46,7 @@ export const generateUniqueId = (prefix='') => _uniqueId(prefix)
  *  setUniqueId([{name: 'item one'}], 'uuid')
  *
  */
- export const setUniqueId = (items, property='id') => {
+export const setUniqueId = (items, property = 'id') => {
   let updatedItems = null
 
   // Assume if first row has an id, they all do and just return items


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As an open source library, we want to treat both TypeScript and JavaScript as first class citizens. While removing propTypes in favor of the Props interface would best support typescript, it would hinder our support for JavaScript. Conversely, leaving the props interfaces out would hinder our support for TypeScript. Originally, I thought that we would have to maintain both the typescript interface and the propTypes to support both languages, but after exploring the propTypes package, I found that you can infer typescript types.

Although I'm sure this isn't perfect, I've found quite a bit of success simply by catching invalid properties in the storybook examples with this approach.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change helps us best support both TypeScript and JavaScript with TeamSnap-UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally against the storybook, and I've added a codeship setup so that we have CI in place to run `npm run build` on push. This should help us avoid issues in the past where un-buildable code had been checked in to master.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
As we didn't have typescript interfaces for Props to begin with, I do not believe this should be a breaking change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.