### PR TITLE
Fix PopupConfirm memory leaks

### DIFF
--- a/src/js/components/Popup/PopupConfirm.tsx
+++ b/src/js/components/Popup/PopupConfirm.tsx
@@ -19,29 +19,35 @@ export default class Popup extends React.Component<
     onCancel: PropTypes.func
   };
 
+  popupRef: PropTypes.InferType<PropTypes.ReactElementLike>;
+
   constructor(props) {
     super(props);
     this.state = {
       isPopupOpen: false
     };
-  }
-
-  componentDidMount() {
-    document.body.addEventListener("click", this.handleBodyClick.bind(this));
-  }
-
-  componentWillUnmount() {
-    document.body.removeEventListener("click", this.handleBodyClick.bind(this));
+    this.popupRef = React.createRef();
   }
 
   handleBodyClick() {
-    this.setState({
-      isPopupOpen: false
-    });
+    if (this.popupRef && this.popupRef.current)
+      this.setState({
+        isPopupOpen: false
+      });
   }
 
   togglePopup() {
-    let isPopupOpen = this.state.isPopupOpen;
+    const { isPopupOpen } = this.state;
+
+    if (!isPopupOpen) {
+      document.body.addEventListener("click", this.handleBodyClick.bind(this));
+    } else {
+      document.body.removeEventListener(
+        "click",
+        this.handleBodyClick.bind(this)
+      );
+    }
+
     this.setState({
       isPopupOpen: !isPopupOpen
     });
@@ -49,7 +55,7 @@ export default class Popup extends React.Component<
 
   render() {
     return (
-      <div className="Popup">
+      <div className="Popup" ref={this.popupRef}>
         <button
           className="Button Button--small"
           onClick={this.togglePopup.bind(this)}

--- a/src/js/components/Popup/PopupConfirm.tsx
+++ b/src/js/components/Popup/PopupConfirm.tsx
@@ -1,18 +1,22 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
 
-
 interface State {
   isPopupOpen: boolean;
 }
 
-export default class Popup extends React.Component<PropTypes.InferProps<typeof Popup.propTypes>, State> {
+export default class Popup extends React.Component<
+  PropTypes.InferProps<typeof Popup.propTypes>,
+  State
+> {
   static propTypes = {
-    buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
-    popUpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+      .isRequired,
+    popUpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+      .isRequired,
     popupStyle: PropTypes.object,
     onAccept: PropTypes.func.isRequired,
-    onCancel: PropTypes.func,
+    onCancel: PropTypes.func
   };
 
   constructor(props) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix memory leaks from occurring, when clicking outside the `<PopupConfirm />` component

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The memory leaks resulted when the following scenarios occurred:
- Popup component is first toggled off, then toggled back on
- Popup component is no longer being rendered, and then a click event happens

In both cases, the `isPopupOpen` state was trying to update during the click event, but the component wasn't being rendered.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is tested in both Storybook (component continues to work as before), and in the project where this component is being implemented (errors are no longer being logged).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.