### PR TITLE
Fix bug where providing a nonexistent default sort would cause table to explode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [3.3.1] - 2020-01-28
+- https://github.com/teamsnap/teamsnap-ui/pull/257
+
+### Fixed
+- `Fixed` Providing nonexistent default sort columns caused table component to fail to render (and throw exceptions)
+
 ## [3.3.0] - 2019-12-05
 - https://github.com/teamsnap/teamsnap-ui/pull/208
 - https://github.com/teamsnap/teamsnap-ui/pull/206

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Table/Table.tsx
+++ b/src/js/components/Table/Table.tsx
@@ -39,7 +39,10 @@ interface State {
   sortByReverse?: any;
 }
 
-class Table extends React.PureComponent<PropTypes.InferProps<typeof Table.propTypes>, State> {
+class Table extends React.PureComponent<
+  PropTypes.InferProps<typeof Table.propTypes>,
+  State
+> {
   static defaultProps = {
     columns: [],
     rows: [],
@@ -99,7 +102,11 @@ class Table extends React.PureComponent<PropTypes.InferProps<typeof Table.propTy
     return Table.getTableState(props, sortByColumn, sortByReverse);
   }
 
-  private static getTableState(props, sortName, sortDirection) {
+  private static getTableState(
+    props: PropTypes.InferProps<typeof Table.propTypes>,
+    sortName: string,
+    sortDirection: boolean
+  ) {
     const { rows } = props;
     const items = setUniqueId(rows);
 
@@ -110,18 +117,25 @@ class Table extends React.PureComponent<PropTypes.InferProps<typeof Table.propTy
     return tableState;
   }
 
-  static sortItems = (props, newItems, sortByColumn, sortByReverse) => {
+  static sortItems = (
+    props: PropTypes.InferProps<typeof Table.propTypes>,
+    newItems: any[],
+    sortByColumn: string,
+    sortByReverse: boolean
+  ) => {
     const { columns } = props;
 
-    const { name, sortType, sortFn } = columns.find(
-      c => c.name === sortByColumn
-    );
-    const items = sortBy(newItems, {
-      name,
-      sortType,
-      sortFn,
-      isReverse: sortByReverse
-    });
+    const sortColumn = columns.find(c => c.name === sortByColumn);
+    let items = newItems;
+    if (sortColumn) {
+      const { name, sortType, sortFn } = sortColumn;
+      items = sortBy(newItems, {
+        name,
+        sortType,
+        sortFn,
+        isReverse: sortByReverse
+      });
+    }
 
     return { items, sortByColumn, sortByReverse };
   };


### PR DESCRIPTION
This PR fixes an issue where the table would fail to render if you provided a default sort that was not one of the column names.

Tested locally against storybook.