### PR TITLE
Disallow CSSNano from messing with z-index

### DIFF
--- a/scripts/gulpfile.js
+++ b/scripts/gulpfile.js
@@ -16,7 +16,7 @@ function buildCSS(config) {
   return gulp.src(config.src)
     .pipe(sass())
     .pipe(autoprefixer('last 2 versions'))
-    .pipe(cssnano())
+    .pipe(cssnano({zindex: false}))
     .pipe(gulp.dest(config.dest))
 }
 


### PR DESCRIPTION
CSS nano tries to be clever by setting `z-index` to their minimum values based on all the values included in the CSS compile. We don't want that since we have other non-TS-UI z-indexes to deal with.

https://medium.com/@barvysta/naughty-cssnano-or-how-to-save-your-z-indexes-from-being-restructured-a42c2ab4241f