### PR TITLE
Add in opinionated pagination table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [3.4.0] - 2020-02-20
+- https://github.com/teamsnap/teamsnap-ui/pull/263
+
+### Added
+- `Added` a component for an opinionated pagination-based table
+
 ## [3.3.2] - 2020-02-12
 - https://github.com/teamsnap/teamsnap-ui/pull/261
 - https://github.com/teamsnap/teamsnap-ui/pull/260

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/utils/space.scss
+++ b/src/css/utils/space.scss
@@ -21,61 +21,65 @@
 //
 
 $spaces: (
-  'None': 0,
-  'Xs': $su-xsmall,
-  'Sm': $su-small,
-  'Md': $su-medium,
-  'Lg': $su-large,
-  'Xl': $su-xlarge,
-  'Xxl': $su-xxlarge
+  "None": 0,
+  "Xs": $su-xsmall,
+  "Sm": $su-small,
+  "Md": $su-medium,
+  "Lg": $su-large,
+  "Xl": $su-xlarge,
+  "Xxl": $su-xxlarge
 );
 
 @each $name, $value in $spaces {
   .u-space#{$name},
   .u-spaceTop#{$name},
   .u-spaceEnds#{$name} {
-   margin-top: $value !important;
+    margin-top: $value !important;
   }
   .u-space#{$name},
   .u-spaceBottom#{$name},
   .u-spaceEnds#{$name} {
-   margin-bottom: $value !important;
+    margin-bottom: $value !important;
   }
   .u-space#{$name},
   .u-spaceRight#{$name},
   .u-spaceSides#{$name} {
-   margin-right: $value !important;
+    margin-right: $value !important;
   }
   .u-space#{$name},
   .u-spaceLeft#{$name},
   .u-spaceSides#{$name} {
-   margin-left: $value !important;
+    margin-left: $value !important;
   }
   .u-pad#{$name},
   .u-padTop#{$name},
   .u-padEnds#{$name} {
-   padding-top: $value !important;
+    padding-top: $value !important;
   }
   .u-pad#{$name},
   .u-padBottom#{$name},
   .u-padEnds#{$name} {
-   padding-bottom: $value !important;
+    padding-bottom: $value !important;
   }
   .u-pad#{$name},
   .u-padRight#{$name},
   .u-padSides#{$name} {
-   padding-right: $value !important;
+    padding-right: $value !important;
   }
   .u-pad#{$name},
   .u-padLeft#{$name},
   .u-padSides#{$name} {
-   padding-left: $value !important;
+    padding-left: $value !important;
   }
 }
 
 .u-spaceSidesAuto {
   margin-right: auto !important;
   margin-left: auto !important;
+}
+
+.u-spaceAuto {
+  margin: auto;
 }
 
 // * Responsive utilities
@@ -87,42 +91,42 @@ $spaces: (
         .u-#{$bp-name}-space#{$name},
         .u-#{$bp-name}-spaceTop#{$name},
         .u-#{$bp-name}-spaceEnds#{$name} {
-         margin-top: $value !important;
+          margin-top: $value !important;
         }
         .u-#{$bp-name}-space#{$name},
         .u-#{$bp-name}-spaceBottom#{$name},
         .u-#{$bp-name}-spaceEnds#{$name} {
-         margin-bottom: $value !important;
+          margin-bottom: $value !important;
         }
         .u-#{$bp-name}-space#{$name},
         .u-#{$bp-name}-spaceRight#{$name},
         .u-#{$bp-name}-spaceSides#{$name} {
-         margin-right: $value !important;
+          margin-right: $value !important;
         }
         .u-#{$bp-name}-space#{$name},
         .u-#{$bp-name}-spaceLeft#{$name},
         .u-#{$bp-name}-spaceSides#{$name} {
-         margin-left: $value !important;
+          margin-left: $value !important;
         }
         .u-#{$bp-name}-pad#{$name},
         .u-#{$bp-name}-padTop#{$name},
         .u-#{$bp-name}-padEnds#{$name} {
-         padding-top: $value !important;
+          padding-top: $value !important;
         }
         .u-#{$bp-name}-pad#{$name},
         .u-#{$bp-name}-padBottom#{$name},
         .u-#{$bp-name}-padEnds#{$name} {
-         padding-bottom: $value !important;
+          padding-bottom: $value !important;
         }
         .u-#{$bp-name}-pad#{$name},
         .u-#{$bp-name}-padRight#{$name},
         .u-#{$bp-name}-padSides#{$name} {
-         padding-right: $value !important;
+          padding-right: $value !important;
         }
         .u-#{$bp-name}-pad#{$name},
         .u-#{$bp-name}-padLeft#{$name},
         .u-#{$bp-name}-padSides#{$name} {
-         padding-left: $value !important;
+          padding-left: $value !important;
         }
       }
 

--- a/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import PaginatedTable from "./PaginatedTable";
+
+const stories = storiesOf("PaginatedTable", module);
+const columns = [
+  { name: "name", label: "Member Name", isSortable: true },
+  { name: "gender", label: "Gender", isSortable: true },
+  { name: "age", label: "Age", isSortable: true },
+  { name: "programs", label: "Active Programs", isSortable: true }
+];
+
+const data = Promise.resolve<any[]>([
+  {
+    name: "Brad",
+    gender: "m",
+    age: 12,
+    position: "Goalie",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
+  },
+  {
+    name: "Dustin",
+    gender: "m",
+    age: 56,
+    position: "Coach",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
+  }
+]);
+
+function loadData(page, itemsPerPage, sortBy) {
+  if (page == 1) {
+    return data.then(items => [items[0]]);
+  } else {
+    return data.then(items => [items[1]]);
+  }
+}
+
+function mapData(item) {
+  return {
+    id: item.name,
+    name: (
+      <div>
+        <div>{item.name}</div>
+        <div>{item.position}</div>
+      </div>
+    ),
+    gender: item.gender,
+    age: `${item.age}`,
+    programs: item.activePrograms.map((p, idx) => <div key={idx}>{p.name}</div>)
+  };
+}
+
+stories.add("Default", () => (
+  <PaginatedTable
+    columns={columns}
+    mapDataToRow={mapData}
+    loadData={loadData}
+    defaultItemsPerPage={1}
+    totalItems={2} // you'll likely need to calculate this in your component by inspecting the http response.
+  />
+));

--- a/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
@@ -78,6 +78,16 @@ const data = Promise.resolve<any[]>([
       { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
       { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
     ]
+  },
+  {
+    name: "Stacy",
+    gender: "f",
+    age: 56,
+    position: "Coach",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
   }
 ]);
 
@@ -120,6 +130,6 @@ stories.add("Default", () => (
     mapDataToRow={mapData}
     loadData={loadData}
     defaultItemsPerPage={1}
-    totalItems={6} // you'll likely need to calculate this in your component by inspecting the http response.
+    totalItems={7} // you'll likely need to calculate this in your component by inspecting the http response.
   />
 ));

--- a/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
@@ -3,6 +3,9 @@ import { storiesOf } from "@storybook/react";
 import PaginatedTable from "./PaginatedTable";
 
 const stories = storiesOf("PaginatedTable", module);
+/**
+ * Columns to configure the table against.
+ */
 const columns = [
   { name: "name", label: "Member Name", isSortable: true },
   { name: "gender", label: "Gender", isSortable: true },
@@ -10,6 +13,9 @@ const columns = [
   { name: "programs", label: "Active Programs", isSortable: true }
 ];
 
+/**
+ * This mock promise data will likely be replaced with an HTTP request in real world applications.
+ */
 const data = Promise.resolve<any[]>([
   {
     name: "Brad",
@@ -75,10 +81,24 @@ const data = Promise.resolve<any[]>([
   }
 ]);
 
-function loadData(page, itemsPerPage, sortBy) {
+/**
+ * This function is where all of your server calls should occur. Commonly likely just make a
+ * server call and return the list of items. However, this is also a good place where you can
+ * inspect the request and determine how many items the server has for this search.
+ * @param page  - the table's current page
+ * @param itemsPerPage - the table's current number of items per page
+ * @param sortBy - the key that the table is sorting by
+ * @param isAscending boolean - true if ascending, false if not.
+ */
+function loadData(page, itemsPerPage, sortBy, isAscending) {
   return data.then(items => [items[page - 1]]);
 }
 
+/**
+ * this function is defined to map a single data item into a single row item.
+ * It is passed in to the paginated table below.
+ * @param item the data item to be mapped to row data
+ */
 function mapData(item) {
   return {
     id: item.name,

--- a/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
@@ -32,15 +32,51 @@ const data = Promise.resolve<any[]>([
       { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
       { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
     ]
+  },
+  {
+    name: "Fred",
+    gender: "m",
+    age: 56,
+    position: "Coach",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
+  },
+  {
+    name: "Bobby",
+    gender: "m",
+    age: 56,
+    position: "Coach",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
+  },
+  {
+    name: "Christie",
+    gender: "f",
+    age: 56,
+    position: "Coach",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
+  },
+  {
+    name: "Jenna",
+    gender: "f",
+    age: 56,
+    position: "Coach",
+    activePrograms: [
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" },
+      { name: "2019 ACC Academy", subtitle: "(Junior Academy Tryout)" }
+    ]
   }
 ]);
 
 function loadData(page, itemsPerPage, sortBy) {
-  if (page == 1) {
-    return data.then(items => [items[0]]);
-  } else {
-    return data.then(items => [items[1]]);
-  }
+  return data.then(items => [items[page - 1]]);
 }
 
 function mapData(item) {
@@ -64,6 +100,6 @@ stories.add("Default", () => (
     mapDataToRow={mapData}
     loadData={loadData}
     defaultItemsPerPage={1}
-    totalItems={2} // you'll likely need to calculate this in your component by inspecting the http response.
+    totalItems={6} // you'll likely need to calculate this in your component by inspecting the http response.
   />
 ));

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { Table } from "../../Table";
 import { usePagination } from "./helpers";
 import PaginationButtons from "./PaginationButtons";
+import PaginationCurrentSubsetDisplay from "./PaginationCurrentSubsetDisplay";
+import PaginationSelect from "./PaginationSelect";
 
 interface Props {
   loadData: (
@@ -50,18 +52,26 @@ const PaginatedTable: React.FunctionComponent<Props> = ({
   return (
     <div className="Grid">
       <div className="Grid Grid-cell Grid--fit Grid--withGutter">
-        <div
-          className="Grid-cell"
-          style={{ display: "flex", justifyContent: "end" }}
-        >
-          <p className="u-pad">
-            <PaginationButtons
-              totalItems={totalItems}
+        <div className="Grid-cell u-sizeFit u-flex u-flexJustifyEnd">
+          <div className="u-spaceAuto u-spaceRightSm">
+            <PaginationCurrentSubsetDisplay
               itemsPerPage={itemsPerPage}
               currentPage={currentPage}
-              setCurrentPage={setCurrentPage}
+              totalItems={totalItems}
             />
-          </p>
+          </div>
+          <PaginationButtons
+            totalItems={totalItems}
+            itemsPerPage={itemsPerPage}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+          />
+          <div className="u-spaceLeftSm">
+            <PaginationSelect
+              options={[10, 25, 50]}
+              setItemsPerPage={setItemsPerPage}
+            />
+          </div>
         </div>
       </div>
       <div className="Grid-cell u-spaceTopSm">

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -9,7 +9,8 @@ interface Props {
   loadData: (
     page: number,
     itemsPerPage: number,
-    sortBy?: string
+    sortBy?: string,
+    sortAsc?: boolean
   ) => Promise<any[]>;
   columns: {
     name: string;
@@ -37,15 +38,22 @@ const PaginatedTable: React.FunctionComponent<Props> = ({
     [currentPage, setCurrentPage]
   ] = usePagination(defaultItemsPerPage || 10, defaultPage || 1);
   const [dataSet, setDataSet] = React.useState([]);
+  const [sortName, setSortName] = React.useState("");
+  const [sortAscending, setSortAscending] = React.useState(false);
 
   React.useEffect(() => {
     const fetchData = async () => {
-      const data = await loadData(currentPage, itemsPerPage);
+      const data = await loadData(
+        currentPage,
+        itemsPerPage,
+        sortName,
+        sortAscending
+      );
       setDataSet(data);
     };
 
     fetchData();
-  }, [itemsPerPage, currentPage]);
+  }, [itemsPerPage, currentPage, sortName, sortAscending]);
 
   const rows = dataSet.map(mapDataToRow);
 
@@ -75,7 +83,14 @@ const PaginatedTable: React.FunctionComponent<Props> = ({
         </div>
       </div>
       <div className="Grid-cell u-spaceTopSm">
-        <Table columns={columns} rows={rows} />
+        <Table
+          columns={columns}
+          rows={rows}
+          externalSortingFunction={(name, ascending) => {
+            setSortName(name);
+            setSortAscending(ascending);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { Table } from "../../Table";
+import { usePagination } from "./helpers";
+import PaginationButtons from "./PaginationButtons";
+
+interface Props {
+  loadData: (
+    page: number,
+    itemsPerPage: number,
+    sortBy?: string
+  ) => Promise<any[]>;
+  columns: {
+    name: string;
+    label: string;
+    isSortable?: boolean;
+    align?: string;
+    mods?: string;
+  }[];
+  mapDataToRow: (item: any) => { id: any };
+  defaultPage?: number;
+  defaultItemsPerPage?: number;
+  totalItems: number;
+}
+
+const PaginatedTable: React.FunctionComponent<Props> = ({
+  loadData,
+  columns,
+  mapDataToRow,
+  defaultPage,
+  defaultItemsPerPage,
+  totalItems
+}) => {
+  const [
+    [itemsPerPage, setItemsPerPage],
+    [currentPage, setCurrentPage]
+  ] = usePagination(defaultItemsPerPage || 10, defaultPage || 1);
+  const [dataSet, setDataSet] = React.useState([]);
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      const data = await loadData(currentPage, itemsPerPage);
+      setDataSet(data);
+    };
+
+    fetchData();
+  }, [itemsPerPage, currentPage]);
+
+  const rows = dataSet.map(mapDataToRow);
+
+  return (
+    <div className="Grid">
+      <div className="Grid Grid-cell Grid--fit Grid--withGutter">
+        <div
+          className="Grid-cell"
+          style={{ display: "flex", justifyContent: "end" }}
+        >
+          <p className="u-pad">
+            <PaginationButtons
+              totalItems={totalItems}
+              itemsPerPage={itemsPerPage}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+            />
+          </p>
+        </div>
+      </div>
+      <div className="Grid-cell u-spaceTopSm">
+        <Table columns={columns} rows={rows} />
+      </div>
+    </div>
+  );
+};
+
+export default PaginatedTable;

--- a/src/js/components/Table/Paginated/PaginationButtons.tsx
+++ b/src/js/components/Table/Paginated/PaginationButtons.tsx
@@ -17,11 +17,10 @@ const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
 >> = ({ totalItems, itemsPerPage, currentPage, setCurrentPage, style }) => {
   const lastPageIndex = getLastPageIndex(totalItems, itemsPerPage);
   const buttonLength = totalItems >= 0 ? lastPageIndex : 0;
-  let maps = 3;
-  if (buttonLength > 3 && currentPage + 3 > buttonLength) {
-    maps = buttonLength + 1 - currentPage;
-  }
-  const buttonMapper = Array(buttonLength > 3 ? maps : buttonLength).fill(0);
+  const MAX_MIDDLE_BUTTONS = 3;
+  const buttonMapper = Array(
+    buttonLength > MAX_MIDDLE_BUTTONS ? MAX_MIDDLE_BUTTONS : buttonLength
+  ).fill(currentPage - 1);
 
   return (
     <ButtonGroup className="ButtonGroup" style={style}>
@@ -33,49 +32,48 @@ const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
       >
         Previous
       </Button>
-      {buttonLength > 3 && currentPage + 3 > totalItems ? (
-        <>
-          <Button
-            className="Button"
-            isDisabled={1 === currentPage}
-            onClick={() => setCurrentPage(1)}
-            type="button"
-          >
-            1
-          </Button>
-          <Button className="Button" type="button">
-            ...
-          </Button>
-        </>
+      <Button
+        className="Button"
+        isDisabled={1 === currentPage}
+        onClick={() => setCurrentPage(1)}
+        type="button"
+      >
+        1
+      </Button>
+      {buttonLength > MAX_MIDDLE_BUTTONS && currentPage > MAX_MIDDLE_BUTTONS ? (
+        <Button className="Button" type="button">
+          ...
+        </Button>
       ) : null}
-      {buttonMapper.map((_v, index) => {
+      {buttonMapper.map((page, index) => {
+        if (page + index <= 1) return null;
+        if (page + index >= buttonLength) return null;
         return (
           <Button
             key={index}
             className="Button"
-            isDisabled={index + 1 === currentPage}
-            onClick={() => setCurrentPage(index + 1)}
+            isDisabled={index + page === currentPage}
+            onClick={() => setCurrentPage(page + index)}
             type="button"
           >
-            {index + currentPage}
+            {index + page}
           </Button>
         );
       })}
-      {buttonLength > 3 && currentPage + 3 <= totalItems ? (
-        <>
-          <Button className="Button" type="button">
-            ...
-          </Button>
-          <Button
-            className="Button"
-            isDisabled={buttonLength === currentPage}
-            onClick={() => setCurrentPage(buttonLength)}
-            type="button"
-          >
-            {buttonLength}
-          </Button>
-        </>
+      {buttonLength > MAX_MIDDLE_BUTTONS &&
+      currentPage + MAX_MIDDLE_BUTTONS <= totalItems ? (
+        <Button className="Button" type="button">
+          ...
+        </Button>
       ) : null}
+      <Button
+        className="Button"
+        isDisabled={buttonLength === currentPage}
+        onClick={() => setCurrentPage(buttonLength)}
+        type="button"
+      >
+        {buttonLength}
+      </Button>
       <Button
         className="Button"
         isDisabled={currentPage === lastPageIndex || lastPageIndex === 0}

--- a/src/js/components/Table/Paginated/PaginationButtons.tsx
+++ b/src/js/components/Table/Paginated/PaginationButtons.tsx
@@ -1,0 +1,62 @@
+import { Button } from "../../Button";
+import { ButtonGroup } from "../../ButtonGroup";
+import { getLastPageIndex } from "./helpers";
+import * as PropTypes from "prop-types";
+import * as React from "react";
+
+const propTypes = {
+  totalItems: PropTypes.number.isRequired,
+  itemsPerPage: PropTypes.number.isRequired,
+  currentPage: PropTypes.number.isRequired,
+  setCurrentPage: PropTypes.func.isRequired,
+  style: PropTypes.object
+};
+
+const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
+  typeof propTypes
+>> = ({ totalItems, itemsPerPage, currentPage, setCurrentPage, style }) => {
+  const lastPageIndex = getLastPageIndex(totalItems, itemsPerPage);
+  const buttonLength = totalItems >= 0 ? lastPageIndex : 0;
+  const buttonMapper = Array(buttonLength).fill(0);
+
+  return (
+    <ButtonGroup className="ButtonGroup" style={style}>
+      <Button
+        className="Button"
+        isActive={false}
+        isDisabled={currentPage === 1}
+        onClick={() => setCurrentPage(currentPage - 1)}
+        type="button"
+      >
+        Previous
+      </Button>
+      {buttonMapper.map((_v, index) => {
+        return (
+          <Button
+            key={index}
+            className="Button"
+            isActive={false}
+            isDisabled={index + 1 === currentPage}
+            onClick={() => setCurrentPage(index + 1)}
+            type="button"
+          >
+            {index + 1}
+          </Button>
+        );
+      })}
+      <Button
+        className="Button"
+        isActive={false}
+        isDisabled={currentPage === lastPageIndex || lastPageIndex === 0}
+        onClick={() => setCurrentPage(currentPage + 1)}
+        type="button"
+      >
+        Next
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+PaginationButtons.propTypes = propTypes;
+
+export default PaginationButtons;

--- a/src/js/components/Table/Paginated/PaginationButtons.tsx
+++ b/src/js/components/Table/Paginated/PaginationButtons.tsx
@@ -17,36 +17,67 @@ const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
 >> = ({ totalItems, itemsPerPage, currentPage, setCurrentPage, style }) => {
   const lastPageIndex = getLastPageIndex(totalItems, itemsPerPage);
   const buttonLength = totalItems >= 0 ? lastPageIndex : 0;
-  const buttonMapper = Array(buttonLength).fill(0);
+  let maps = 3;
+  if (buttonLength > 3 && currentPage + 3 > buttonLength) {
+    maps = buttonLength + 1 - currentPage;
+  }
+  const buttonMapper = Array(buttonLength > 3 ? maps : buttonLength).fill(0);
 
   return (
     <ButtonGroup className="ButtonGroup" style={style}>
       <Button
         className="Button"
-        isActive={false}
         isDisabled={currentPage === 1}
         onClick={() => setCurrentPage(currentPage - 1)}
         type="button"
       >
         Previous
       </Button>
+      {buttonLength > 3 && currentPage + 3 > totalItems ? (
+        <>
+          <Button
+            className="Button"
+            isDisabled={1 === currentPage}
+            onClick={() => setCurrentPage(1)}
+            type="button"
+          >
+            1
+          </Button>
+          <Button className="Button" type="button">
+            ...
+          </Button>
+        </>
+      ) : null}
       {buttonMapper.map((_v, index) => {
         return (
           <Button
             key={index}
             className="Button"
-            isActive={false}
             isDisabled={index + 1 === currentPage}
             onClick={() => setCurrentPage(index + 1)}
             type="button"
           >
-            {index + 1}
+            {index + currentPage}
           </Button>
         );
       })}
+      {buttonLength > 3 && currentPage + 3 <= totalItems ? (
+        <>
+          <Button className="Button" type="button">
+            ...
+          </Button>
+          <Button
+            className="Button"
+            isDisabled={buttonLength === currentPage}
+            onClick={() => setCurrentPage(buttonLength)}
+            type="button"
+          >
+            {buttonLength}
+          </Button>
+        </>
+      ) : null}
       <Button
         className="Button"
-        isActive={false}
         isDisabled={currentPage === lastPageIndex || lastPageIndex === 0}
         onClick={() => setCurrentPage(currentPage + 1)}
         type="button"

--- a/src/js/components/Table/Paginated/PaginationCurrentSubsetDisplay.tsx
+++ b/src/js/components/Table/Paginated/PaginationCurrentSubsetDisplay.tsx
@@ -1,0 +1,26 @@
+import * as PropTypes from "prop-types";
+import * as React from "react";
+
+const propTypes = {
+  currentPage: PropTypes.number.isRequired,
+  totalItems: PropTypes.number.isRequired,
+  itemsPerPage: PropTypes.number.isRequired
+};
+
+const PaginationCurrentSubsetDisplay: React.FunctionComponent<PropTypes.InferProps<
+  typeof propTypes
+>> = ({ totalItems, itemsPerPage, currentPage }) => {
+  return (
+    <>
+      {(currentPage - 1) * itemsPerPage + 1} -{" "}
+      {currentPage * itemsPerPage < totalItems
+        ? currentPage * itemsPerPage
+        : totalItems}{" "}
+      of {totalItems}
+    </>
+  );
+};
+
+PaginationCurrentSubsetDisplay.propTypes = propTypes;
+
+export default PaginationCurrentSubsetDisplay;

--- a/src/js/components/Table/Paginated/PaginationSelect.tsx
+++ b/src/js/components/Table/Paginated/PaginationSelect.tsx
@@ -1,0 +1,33 @@
+import { Select } from "../../Select";
+import * as PropTypes from "prop-types";
+import * as React from "react";
+
+const propTypes = {
+  options: PropTypes.arrayOf(PropTypes.number).isRequired,
+  setItemsPerPage: PropTypes.func.isRequired
+};
+
+const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
+  typeof propTypes
+>> = ({ setItemsPerPage, options }) => {
+  const selectOptions = options.map(num => ({
+    label: `${num} Rows`,
+    value: "" + num
+  }));
+  return (
+    <Select
+      name="standardSelect"
+      style={{ width: "inherit" }} // override this style
+      options={selectOptions}
+      inputProps={{
+        onChange: event => {
+          setItemsPerPage(+event.target.value);
+        }
+      }}
+    />
+  );
+};
+
+PaginationButtons.propTypes = propTypes;
+
+export default PaginationButtons;

--- a/src/js/components/Table/Paginated/PaginationSelect.tsx
+++ b/src/js/components/Table/Paginated/PaginationSelect.tsx
@@ -7,7 +7,7 @@ const propTypes = {
   setItemsPerPage: PropTypes.func.isRequired
 };
 
-const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
+const PaginationSelect: React.FunctionComponent<PropTypes.InferProps<
   typeof propTypes
 >> = ({ setItemsPerPage, options }) => {
   const selectOptions = options.map(num => ({
@@ -28,6 +28,6 @@ const PaginationButtons: React.FunctionComponent<PropTypes.InferProps<
   );
 };
 
-PaginationButtons.propTypes = propTypes;
+PaginationSelect.propTypes = propTypes;
 
-export default PaginationButtons;
+export default PaginationSelect;

--- a/src/js/components/Table/Paginated/helpers.tsx
+++ b/src/js/components/Table/Paginated/helpers.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+export const getLastPageIndex = (
+  totalItems: number,
+  itemsPerPage: number
+): number => {
+  const index = parseInt("" + totalItems / (itemsPerPage + 1), 10) + 1;
+  return Math.max(1, index);
+};
+
+export const usePagination = (
+  defaultItemsPerPage: number,
+  defaultCurrentPage: number
+) => {
+  const itemsPerPageStateHooks = React.useState(defaultItemsPerPage);
+  const currentPageStateHooks = React.useState(defaultCurrentPage);
+
+  return [itemsPerPageStateHooks, currentPageStateHooks];
+};

--- a/src/js/components/Table/Paginated/helpers.tsx
+++ b/src/js/components/Table/Paginated/helpers.tsx
@@ -4,7 +4,7 @@ export const getLastPageIndex = (
   totalItems: number,
   itemsPerPage: number
 ): number => {
-  const index = parseInt("" + totalItems / (itemsPerPage + 1), 10) + 1;
+  const index = totalItems / itemsPerPage;
   return Math.max(1, index);
 };
 

--- a/src/js/components/Table/Paginated/index.ts
+++ b/src/js/components/Table/Paginated/index.ts
@@ -1,0 +1,2 @@
+import PaginatedTable from "./PaginatedTable";
+export { PaginatedTable };

--- a/src/js/components/Table/Table.tsx
+++ b/src/js/components/Table/Table.tsx
@@ -74,6 +74,7 @@ class Table extends React.PureComponent<
     ),
     rows: PropTypes.arrayOf(PropTypes.object),
     defaultSort: PropTypes.string,
+    externalSortingFunction: PropTypes.func,
     isStriped: PropTypes.bool,
     className: PropTypes.string,
     mods: PropTypes.string,
@@ -147,6 +148,13 @@ class Table extends React.PureComponent<
 
     const sortDirection =
       sortName === this.state.sortByColumn ? !this.state.sortByReverse : false;
+
+    // If an function is provided here, we let the parent component figure out the sorting
+    // This is valuable when we sort beyond the data thats currently in the table
+    // IE: We keep data on the server and want to sort against that or are supporting pagination.
+    if (this.props.externalSortingFunction != null) {
+      this.props.externalSortingFunction(sortName, sortDirection);
+    }
     const tableState = Table.sortItems(
       this.props,
       items,

--- a/src/js/components/Table/index.ts
+++ b/src/js/components/Table/index.ts
@@ -1,2 +1,3 @@
 import Table from "./Table";
-export { Table };
+import { PaginatedTable } from "./Paginated";
+export { Table, PaginatedTable };


### PR DESCRIPTION
This PR adds in a table that has wired up pagination controls and works with asynchronous data. This seems to be a common theme with several of our frontend applications, and the current table's sorting doesn't play nicely with paginated data, so this is an attempt to help remedy that situation by providing an easy to use solution.