### PR TITLE
adding an orange modifier to progress bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [3.15.0] - 2020-03-17
+- https://github.com/teamsnap/teamsnap-ui/pull/269
+- `Added` orange as a color for the progress bar
+
 ## [3.4.1] - 2020-02-20
 - https://github.com/teamsnap/teamsnap-ui/pull/265
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/components/Progress.scss
+++ b/src/css/components/Progress.scss
@@ -292,6 +292,14 @@
 
 }
 
+.ProgressBar--highlight {
+
+  .ProgressBar-status {
+    background: $cu-highlight;
+  }
+
+}
+
 .RadialProgress--neutral {
 
   .RadialProgress-status {
@@ -304,6 +312,14 @@
 
   .RadialProgress-status {
     border-color: $cu-negative;
+  }
+
+}
+
+.RadialProgress--highlight {
+
+  .RadialProgress-status {
+    border-color: $cu-highlight;
   }
 
 }

--- a/src/js/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/js/components/ProgressBar/ProgressBar.stories.tsx
@@ -75,6 +75,9 @@ stories.add(
         <h4>Negative</h4>
         <ProgressBar progress={66} color="negative" size={size} />
         <br />
+        <h4>Highlight</h4>
+        <ProgressBar progress={66} color="highlight" size={size} />
+        <br />
         <h4>Default Color</h4>
         <ProgressBar progress={100} size={size} />
         <br />

--- a/src/js/components/RadialProgress/RadialProgress.stories.tsx
+++ b/src/js/components/RadialProgress/RadialProgress.stories.tsx
@@ -28,6 +28,9 @@ stories.add(
         <h4>Negative</h4>
         <RadialProgress progress={66} color="negative" size={size} />
         <br />
+        <h4>Highlight</h4>
+        <RadialProgress progress={66} color="highlight" size={size} />
+        <br />
         <h4>Default Color</h4>
         <RadialProgress progress={100} size={size} />
         <br />


### PR DESCRIPTION
<img width="500" alt="Screen Shot 2020-03-16 at 1 23 26 PM" src="https://user-images.githubusercontent.com/1189536/76792881-9703a380-6789-11ea-96e2-0769152ce8f4.png">
<img width="1295" alt="Screen Shot 2020-03-16 at 1 23 35 PM" src="https://user-images.githubusercontent.com/1189536/76792884-979c3a00-6789-11ea-9df3-592e9e38ac13.png">
