### PR TITLE
Make popup more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Fixed` for any bug fixes.
 - `Security`
 
+## [3.10.0] - 2020-11-04
+- https://github.com/teamsnap/teamsnap-ui/pull/366
+- `Added` more options to Popup component to make it more customizable.
+
 ## [3.9.2] - 2020-11-04
 - https://github.com/teamsnap/teamsnap-ui/pull/366
 - `Fixed` Popup component - popup would not "stick" when trigger was clicked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { select } from "@storybook/addon-knobs/react";
+import { Icon } from "../Icon";
 import PopupAction from "./PopupAction";
 import PopupConfirm from "./PopupConfirm";
 
@@ -29,7 +30,7 @@ stories.add("PopupActions", () => {
       text="..."
       actions={actions}
       direction={["down", "left"]}
-      popupStyle={{ width: "150px" }}
+      popupStyle={{ width: "150px", left: "-16px" }}
     />
   );
 });
@@ -38,6 +39,12 @@ stories.add("PopupConfirm", () => {
   const popupText = (
     <h4>Do you really want to hurt me? Do you really want to make me cry?</h4>
   );
+  const negativePopUpText = (
+    <div class="u-textCenter">
+      <h3>Delete this Row?</h3>
+      <p>This action cannot be undone.</p>
+    </div>
+  );
   const onAccept = () => {
     alert("You said yes!");
   };
@@ -45,11 +52,39 @@ stories.add("PopupConfirm", () => {
     alert("Good. I dont want to hurt or cry.");
   };
   return (
-    <PopupConfirm
-      onAccept={onAccept}
-      onCancel={onCancel}
-      buttonText="Perform the Culture Club!"
-      popUpText={popupText}
-    />
+    <>
+      <PopupConfirm
+        direction={["down", "left"]}
+        popupStyle={{ left: "-16px", width: "270px" }}
+        onAccept={onAccept}
+        onCancel={onCancel}
+        buttonText={<Icon name="trash" style={{ color: '#e26362' }} />}
+        cancelButtonText="Cancel"
+        cancelButtonMods=""
+        confirmButtonText="Delete"
+        confirmButtonMods="Button--no"
+        popUpText={negativePopUpText}
+        popUpMods="Popup--hover"
+      />
+      <PopupConfirm
+        popUpMods="u-spaceSidesMd"
+        direction={["down"]}
+        onAccept={onAccept}
+        onCancel={onCancel}
+        buttonText={"Negative Button, Down"}
+        buttonMods="Button--negative"
+        cancelButtonText="Cancel"
+        cancelButtonMods=""
+        confirmButtonText="Confirm"
+        confirmButtonMods="Button--no"
+        popUpText={negativePopUpText}
+      />
+      <PopupConfirm
+        onAccept={onAccept}
+        onCancel={onCancel}
+        buttonText={"Default"}
+        popUpText={popupText}
+      />
+    </>
   );
 });

--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -40,7 +40,7 @@ stories.add("PopupConfirm", () => {
     <h4>Do you really want to hurt me? Do you really want to make me cry?</h4>
   );
   const negativePopUpText = (
-    <div class="u-textCenter">
+    <div className="u-textCenter">
       <h3>Delete this Row?</h3>
       <p>This action cannot be undone.</p>
     </div>

--- a/src/js/components/Popup/PopupConfirm.tsx
+++ b/src/js/components/Popup/PopupConfirm.tsx
@@ -10,13 +10,30 @@ export default class Popup extends React.Component<
   State
 > {
   static propTypes = {
-    buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-      .isRequired,
+    popUpMods: PropTypes.string,
     popUpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
       .isRequired,
+    direction: PropTypes.arrayOf(PropTypes.oneOf(["down", "right", "left", "rightHang", "leftHang", "overlay"])),
     popupStyle: PropTypes.object,
+    buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element])
+      .isRequired,
+    buttonMods: PropTypes.string,
+    confirmButtonText: PropTypes.string,
+    confirmButtonMods: PropTypes.string,
+    cancelButtonText: PropTypes.string,
+    cancelButtonMods: PropTypes.string,
     onAccept: PropTypes.func.isRequired,
     onCancel: PropTypes.func
+  };
+
+  static defaultProps = {
+    direction: ["overlay"],
+    popUpMods: "",
+    buttonMods: "Button--small",
+    confirmButtonText: "Confirm",
+    confirmButtonMods: "Button--primary",
+    cancelButtonText: "Cancel",
+    cancelButtonMods: "Button--negative",
   };
 
   popupRef: PropTypes.InferType<PropTypes.ReactElementLike>;
@@ -54,19 +71,20 @@ export default class Popup extends React.Component<
   }
 
   render() {
+    const dirString = this.props.direction.reduce((acc, cur) => {
+      return acc + ` Popup-container--${cur}`;
+    }, "");
+
     return (
-      <div className="Popup" ref={this.popupRef}>
+      <div className={`Popup ${this.props.popUpMods}`} ref={this.popupRef}>
         <button
-          className="Button Button--small"
+          className={`Button ${this.props.buttonMods}`}
           onClick={this.togglePopup.bind(this)}
         >
           {this.props.buttonText}
         </button>
         <div
-          className={
-            "Popup-container Popup-container--overlay" +
-            (this.state.isPopupOpen ? " is-open" : "")
-          }
+          className={`Popup-container ${dirString} ${this.state.isPopupOpen ? "is-open" : ""}`}
           style={this.props.popupStyle}
         >
           <div className="Popup-content u-padMd">
@@ -74,15 +92,15 @@ export default class Popup extends React.Component<
             <div className="u-textCenter u-spaceTopMd">
               <button
                 onClick={this.props.onCancel}
-                className="u-spaceRightSm Button Button--negative"
+                className={`u-spaceRightSm Button ${this.props.cancelButtonMods}`}
               >
-                Cancel
+                {this.props.cancelButtonText}
               </button>
               <button
                 onClick={this.props.onAccept}
-                className="Button Button--primary"
+                className={`Button ${this.props.confirmButtonMods}`}
               >
-                Confirm
+                {this.props.confirmButtonText}
               </button>
             </div>
           </div>


### PR DESCRIPTION
Make the popup confirm component more flexible by supporting extra classes, variable button text and adding direction. I added defaults for all the old static properties so it shouldn't impact components in the wild.

![popup](https://user-images.githubusercontent.com/9888467/100797887-726b5c80-33e8-11eb-9ccc-0ba3bdb20332.gif)


