### PR TITLE
add in toolbar for alphav4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/components/Nav.scss
+++ b/src/css/components/Nav.scss
@@ -40,6 +40,7 @@
   border-bottom: 1px solid color-neutral(5);
   padding: scaleGrid(2);
   font-size: 1.4rem;
+  max-height: 65px;
 }
 
 .Nav-body {

--- a/src/css/components/Toolbar.scss
+++ b/src/css/components/Toolbar.scss
@@ -1,0 +1,6 @@
+@import "../config/index.scss";
+
+.Toolbar {
+  border-bottom: 1px solid color-neutral(4);
+  padding: scaleGrid(2);
+}

--- a/src/css/components/index.scss
+++ b/src/css/components/index.scss
@@ -22,4 +22,5 @@
 @import "SummaryList";
 @import "Tabs";
 @import "Toggle";
+@import "Toolbar";
 @import "Tooltip";

--- a/src/css/utils/flex.scss
+++ b/src/css/utils/flex.scss
@@ -73,6 +73,10 @@
   justify-content: space-around !important;
 }
 
+.u-flexJustifyEvenly {
+  justify-content: space-evenly !important;
+}
+
 
 // * Align items in the cross axis of the current line of the flex container
 // * Similar to `justify-content` but in the perpendicular direction

--- a/src/js/components/Toolbar/Toolbar.stories.tsx
+++ b/src/js/components/Toolbar/Toolbar.stories.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import Toolbar from "./Toolbar";
+import { Nav } from "../Nav";
+
+const stories = storiesOf("Toolbar", module);
+
+stories.add("Default", () => (
+  <>
+    <Toolbar />
+  </>
+));
+
+stories.add("Ideal toolbar placement", () => {
+  return (
+    <>
+      <div
+        className="u-flex"
+        style={{
+          minHeight: "80vh",
+        }}
+      >
+        <Nav
+          headerItems={ [
+            {
+              image:
+                "https://aa5498032991a101442c-34c0f4eec246050dfc1ee92670a7b97d.ssl.cf1.rackcdn.com/logo-icon-dafd29abff7b6ca55ad71c35bd34d679.png",
+              title: "sample",
+            },
+          ] }
+          mods="u-size2of12"
+        >
+          <Nav.Item icon="divisions">Programs</Nav.Item>
+        </Nav>
+        <main className="u-sizeFill u-flex u-flexJustifyCenter">
+          <div style={{ width: "100%" }}>
+          <Toolbar />
+          <div>
+          Page content here.
+          </div>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+});

--- a/src/js/components/Toolbar/Toolbar.stories.tsx
+++ b/src/js/components/Toolbar/Toolbar.stories.tsx
@@ -44,3 +44,37 @@ stories.add("Ideal toolbar placement", () => {
     </>
   );
 });
+
+stories.add("With Search", () => {
+  return (
+    <>
+      <div
+        className="u-flex"
+        style={{
+          minHeight: "80vh",
+        }}
+      >
+        <Nav
+          headerItems={ [
+            {
+              image:
+                "https://aa5498032991a101442c-34c0f4eec246050dfc1ee92670a7b97d.ssl.cf1.rackcdn.com/logo-icon-dafd29abff7b6ca55ad71c35bd34d679.png",
+              title: "sample",
+            },
+          ] }
+          mods="u-size2of12"
+        >
+          <Nav.Item icon="divisions">Programs</Nav.Item>
+        </Nav>
+        <main className="u-sizeFill u-flex u-flexJustifyCenter">
+          <div style={{ width: "100%" }}>
+          <Toolbar showSearch />
+          <div>
+          Page content here.
+          </div>
+          </div>
+        </main>
+      </div>
+    </>
+  );
+});

--- a/src/js/components/Toolbar/Toolbar.tsx
+++ b/src/js/components/Toolbar/Toolbar.tsx
@@ -1,0 +1,117 @@
+/**
+ * @name Tooltip
+ *
+ * @description
+ * An element to display an icon and help text on hover.  See the teamsnap patterns library for more information.
+ * https://teamsnap-ui-patterns.netlify.com/patterns/components/tooltip.html
+ *
+ * @example
+ *  <Tooltip type='icon' text="I'm some help text.">
+ *   Icon or Text to Render as Child
+ *  </Tooltip>
+ *
+ */
+
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import { Icon } from "../Icon";
+import { Field } from "../Field";
+
+const propTypes = {
+  showSearch: PropTypes.bool,
+  showHelp: PropTypes.bool,
+  showAccount: PropTypes.bool,
+  accountName: PropTypes.string,
+  showActivity: PropTypes.bool,
+};
+
+const Tooltip: React.FunctionComponent<
+  PropTypes.InferProps<typeof propTypes>
+> = ({ showSearch, accountName, showHelp, showAccount, showActivity }) => {
+  return (
+    <div className="Grid Toolbar">
+      <div className="Grid-cell u-size3of4">
+        {showSearch && (
+          <Field
+            formFieldProps={{
+              placeholder: "Find a program, season, or member",
+              leftIcon: <Icon className="Icon" name="search" />,
+            }}
+            name="Sample"
+          />
+        )}
+      </div>
+      <div className="Grid-cell u-size1of4 u-flex u-flexAlignContentCenter u-flexJustifyEvenly u-padXs">
+        <span style={{ cursor: "pointer" }}>
+          {showHelp && (
+            <>
+              <Icon
+                className="Icon"
+                name="info"
+                style={{
+                  border: "1px solid black",
+                  borderRadius: "12px",
+                  padding: "4px",
+                  width: "24px",
+                  height: "24px",
+                  marginRight: "4px",
+                }}
+              />
+              <span>Help</span>
+            </>
+          )}
+        </span>
+        <span style={{ cursor: "pointer" }}>
+          {showAccount && (
+            <>
+              <Icon
+                className="Icon"
+                name="user"
+                style={{
+                  border: "1px solid black",
+                  borderRadius: "12px",
+                  padding: "4px",
+                  width: "24px",
+                  height: "24px",
+                  marginRight: "4px",
+                }}
+              />
+              { accountName || "Account" }
+            </>
+          )}
+        </span>
+        <span style={{ cursor: "pointer" }}>
+          {showActivity && (
+            <>
+              <Icon
+                className="Icon"
+                name="notifications"
+                style={{
+                  border: "1px solid black",
+                  borderRadius: "12px",
+                  padding: "4px",
+                  width: "24px",
+                  height: "24px",
+                  marginRight: "4px",
+                }}
+              />
+              Activity
+            </>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+Tooltip.propTypes = propTypes;
+
+Tooltip.defaultProps = {
+  accountName: "Account",
+  showAccount: true,
+  showSearch: false,
+  showActivity: true,
+  showHelp: true
+};
+
+export default Tooltip;

--- a/src/js/components/Toolbar/index.ts
+++ b/src/js/components/Toolbar/index.ts
@@ -1,0 +1,2 @@
+import Toolbar from "./Toolbar";
+export { Toolbar };


### PR DESCRIPTION
Icons are temporary until we replace Pika with whatever icon set we're using for v4.

<img width="1410" alt="Screen Shot 2021-02-01 at 3 56 11 PM" src="https://user-images.githubusercontent.com/1455979/106517292-4e8acc80-64a6-11eb-9b60-887e4d0c728f.png">

<img width="1409" alt="Screen Shot 2021-02-01 at 3 58 10 PM" src="https://user-images.githubusercontent.com/1455979/106517294-4f236300-64a6-11eb-803b-e2745014b9bd.png">
