### PR TITLE
Adjust color generation to play nicely with postcss imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/utils/color.scss
+++ b/src/css/utils/color.scss
@@ -1,11 +1,24 @@
-$permutations: "Primary", "Negative", "Warning", "Success", "Neutral";
 $maxIndex: 999;
 
-@each $fn in $permutations {
-  @for $i from 1 through 9 {
-    .u-color#{$fn}#{$i} {
-      color: call(get-function(to-lower-case(str-insert("color-", $fn, $maxIndex))), $i) !important;
-    }
+@for $i from 1 through 9 {
+  .u-colorPrimary#{$i} {
+    color: color-primary($i) !important;
+  }
+
+  .u-colorNegative#{$i} {
+    color: color-negative($i) !important;
+  }
+
+  .u-colorWarning#{$i} {
+    color: color-warning($i) !important;
+  }
+
+  .u-colorSuccess#{$i} {
+    color: color-success($i) !important;
+  }
+
+  .u-colorNeutral#{$i} {
+    color: color-neutral($i) !important;
   }
 }
 


### PR DESCRIPTION
When importing our themes into .scss that ultimately gets shoveled into a postcss loader, we're seeing issues with our dynamic function lookup. This PR modifies that so that the dynamic function lookup is inlined (adds a few extra lines) but works with PostCSS loaders.

Here was the original stacktrace that caused this:
```
./src/styles/main.module.scss (../node_modules/css-loader/dist/cjs.js??ref--5-oneOf-7-1!../node_modules/postcss-loader/src??postcss!../node_modules/resolve-url-loader??ref--5-oneOf-7-3!../node_modules/sass-loader/dist/cjs.js??ref--5-oneOf-7-4!./src/styles/main.module.scss)
SassError: Function not found: color-primary
        on line 7 of ../node_modules/@teamsnap/teamsnap-ui/src/css/utils/color.scss, in function `get-function`
        from line 7 of ../node_modules/@teamsnap/teamsnap-ui/src/css/utils/color.scss
        from line 2 of ../node_modules/@teamsnap/teamsnap-ui/src/css/utils/index.scss
```

I thought it was just one of our repos using CSS Modules, but we have another Repo that is experiencing similar symptoms and is not using CSS Modules. 