### PR TITLE
SO-4191 Misc style updates

### DIFF
--- a/src/css/components/Button.scss
+++ b/src/css/components/Button.scss
@@ -3,7 +3,7 @@
 // * @define default Button
 
 // Global default button colors that are themed
-$button-color:                       color-neutral(1) !default;
+$button-color:                       $ts-white !default;
 $button-border-color:                color-neutral(5) !default;
 $button-text-color:                  color-neutral(9) !default;
 

--- a/src/css/components/Button.scss
+++ b/src/css/components/Button.scss
@@ -70,7 +70,6 @@ $Button-active-color: color-primary(7);
 
 $permutations: (
   "primary" color-primary(6) color-primary(5) color-primary(7),
-  "negative" color-negative(6) color-negative(5) color-negative(7),
   "warning" color-warning(6) color-warning(5) color-warning(7),
   "success" color-success(6) color-success(5) color-success(7)
 );

--- a/src/css/components/Nav.scss
+++ b/src/css/components/Nav.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   min-width: scaleGrid(24);
-  max-width: scaleGrid(27);
+  max-width: scaleGrid(25);
 
   &.is-flyout {
     background-color: white;
@@ -28,7 +28,7 @@
   }
 
   .Nav-item {
-    color: color-primary(1);
+    color: color-neutral(5);
     white-space: nowrap;
   }
 
@@ -53,6 +53,7 @@
     }
 
     .Nav-header {
+      height: 57px;
       margin: 0 auto;
       padding: scaleGrid(2);
     }
@@ -121,12 +122,13 @@
   border-radius: 5px;
   cursor: pointer;
   list-style: none;
-  margin: scaleGrid(2) scaleGrid(1);
-  padding: scaleGrid(1);
+  margin: scaleGrid(3) 12px;
+  padding: 6px 12px;
   user-select: none;
 
   &:hover {
     background-color: color-primary(8);
+    color: color-primary(1);
     transition: all ease 200ms;
   }
 
@@ -137,5 +139,6 @@
   &.is-active {
     background-color: color-primary(6);
     color:color-neutral(1);
+    font-weight: bold;
   }
 }

--- a/src/css/components/Panel.scss
+++ b/src/css/components/Panel.scss
@@ -151,7 +151,7 @@ $Panel-header-text-color: $cu-info !default;
 }
 
 .Panel-body[role="table"] .Panel-row[role="row"] .Panel-cell {
-  font-size: $tu-large-fontSize;
+  font-size: $tu-base-fontSize;
 }
 
 // Override everything-selector that sets max width on -header, -footer, -row
@@ -222,7 +222,7 @@ $Panel-header-text-color: $cu-info !default;
 .Panel-title {
   color: $Panel-header-text-color; // 1
   font-family: $base-font-family; // 1
-  font-size: $tu-medium-fontSize; // 1
+  font-size: $tu-base-fontSize; // 1
   font-weight: $tu-semibold-fontWeight; // 1
   flex: 1 1 0%; // 2
   padding: 0; // 3

--- a/src/css/components/Tabs.scss
+++ b/src/css/components/Tabs.scss
@@ -21,14 +21,12 @@
 }
 
 .Tabs-headerItem {
-
   list-style: none;
   display: inline-block;
   position: relative;
   cursor: pointer;
-  color: color-primary(6);
+  color: color-neutral(9);
   font-family: $base-font-family;
-  font-weight: $tu-semibold-fontWeight;
 
   &, &:last-child {
     padding: $su-xsmall $su-large;
@@ -45,7 +43,11 @@
     background: transparent;
   }
 
-  &.is-active,
+  &.is-active {
+    color: color-primary(5);
+    font-weight: $tu-semibold-fontWeight;
+  }
+
   &:hover {
     color: color-primary(5);
   }

--- a/src/css/components/Toolbar.scss
+++ b/src/css/components/Toolbar.scss
@@ -3,6 +3,7 @@
 .Toolbar {
   border-bottom: 1px solid color-neutral(4);
   padding: scaleGrid(2);
+  height: 57px;
 }
 
 .Toolbar-flyout {

--- a/src/css/config/config.scss
+++ b/src/css/config/config.scss
@@ -256,8 +256,8 @@ $site-container: 1300px;
 
 // * 5. Borders
 
-$border-radius-small:  scaleGrid(-2) !default; // 2px
-$border-radius-medium: scaleGrid(-1) !default; // 4px
+$border-radius-small:   scaleGrid(-2) !default; // 2px
+$border-radius-medium:  5px !default;          // 4px
 $border-radius-large:   scaleGrid(1) !default; // 8px
 
 $border-width-small:   scaleGrid(-3) !default; // 1px

--- a/src/css/config/themes/league.scss
+++ b/src/css/config/themes/league.scss
@@ -18,6 +18,6 @@
 
 // * 2. Redefine Color, Element, & Font Variables for Theme
 
-$cu-primary:  #13426E;
-$color-links: #3079b7;
+$cu-primary:  #1D2B35;
+$color-links: #0057BE;
 $Modal-style: 'Panel';


### PR DESCRIPTION
## Description
These changes stem from: https://teamsnap.atlassian.net/browse/SO-4191

Here's some context behind a few of the changes:

**Restore base font size to panels**
I'm reverting the larger font sizes until we can apply it to more of the app. Right now, we have an inconsistent mix of 13-16px appearing in the body.

<img width="400" alt="Screen Shot 2021-03-02 at 8 57 20 AM" src="https://user-images.githubusercontent.com/1085718/109659244-7a48b300-7b35-11eb-9309-65b80ac76c6b.png">

 **Remove negative button style**
Cancel buttons should appear more neutral. So until we can change the markup across the app, I removed the `negative` button style.

<img width="400" alt="Screen Shot 2021-03-02 at 9 03 19 AM" src="https://user-images.githubusercontent.com/1085718/109659851-27233000-7b36-11eb-88f6-4ec92b50ba85.png">

