### PR TITLE
Add peer dependencies for react

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
     "@babel/runtime": "^7.5.5",
     "core-js": "^3.1.4",
     "lodash": "^4.17.15"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0"
   }
 }


### PR DESCRIPTION
TeamSnap UI needs to specify react as a peer dependency. Yarn 2 throws errors around this, but this extra level of declaration can help any consumer of TeamSnap UI.