### PR TITLE
center all elements of bottom pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Security`
 
 ## [3.10.5] - 2021-04-06
+- https://github.com/teamsnap/teamsnap-ui/pull/581
+- `Updated` Center paginated table elements as a group
+
+## [3.10.5] - 2021-04-06
 - https://github.com/teamsnap/teamsnap-ui/pull/564
 - `Added` Allow paginated table to export placement options type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -188,8 +188,8 @@ const PaginatedTable: React.FunctionComponent<Props> & { PaginationPlacement: ty
   }, [customFilter]);
 
   const paginationItems = (
-  <div className={ `Grid-cell u-spaceTopSm u-flex u-flexJustifyEnd ${paginationPlacement == Placement.Bottom ? "u-sizeFill u-sizeFull" : "u-sizeFit"}` }>
-    <div className="u-spaceAuto u-spaceRightSm">
+  <div className={ `Grid-cell u-spaceTopSm u-flex u-flexAlignItemsCenter ${paginationPlacement == Placement.Bottom ? " u-flexJustifyCenter u-sizeFill u-sizeFull" : " u-flexJustifyEnd u-sizeFit"}` }>
+    <div className="u-spaceRightSm">
       <PaginationCurrentSubsetDisplay
         itemsPerPage={ itemsPerPage }
         currentPage={ currentPage }
@@ -201,7 +201,6 @@ const PaginatedTable: React.FunctionComponent<Props> & { PaginationPlacement: ty
       itemsPerPage={ itemsPerPage }
       currentPage={ currentPage }
       setCurrentPage={ setCurrentPage }
-      mods={ paginationPlacement == Placement.Bottom ? "u-flexJustifyCenter u-flexGrow1" : "" }
     />
     { !hideRowsSelect ? (
       <div className="u-spaceLeftSm">


### PR DESCRIPTION
Small tweak to alignment in pagination placement to center elements as a group. To better match mockup in: https://teamsnap.atlassian.net/browse/SO-4361

before
<img width="1177" alt="Screen Shot 2021-04-12 at 9 24 01 AM" src="https://user-images.githubusercontent.com/81430847/114421477-939c4080-9b72-11eb-996f-12af6fba68c9.png">
after
<img width="1177" alt="Screen Shot 2021-04-12 at 9 24 27 AM" src="https://user-images.githubusercontent.com/81430847/114421497-972fc780-9b72-11eb-8ea6-f753a094bd66.png">

top placement before
<img width="1177" alt="Screen Shot 2021-04-12 at 9 23 43 AM" src="https://user-images.githubusercontent.com/81430847/114421579-add61e80-9b72-11eb-95ad-30a9e570651d.png">
top placement after (no changes)
<img width="1177" alt="Screen Shot 2021-04-12 at 9 24 38 AM" src="https://user-images.githubusercontent.com/81430847/114421626-b9c1e080-9b72-11eb-8cba-109911186f71.png">
