### PR TITLE
Modify buttons to have a minimum height

### DIFF
--- a/src/css/components/Button.scss
+++ b/src/css/components/Button.scss
@@ -35,14 +35,13 @@ $Button-padding: 0 scaleGrid(2);
   font-family: $Button-font-family;
   font-size: $Button-font-size;
   font-weight: $Button-font-weight;
-  height: $Button-height;
+  min-height: $Button-height;
   line-height: $Button-line-height;
   margin: 0;
   padding: $Button-padding;
   text-decoration: none;
   transition: all $duration-short ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
 
   &:hover,
   &:active,


### PR DESCRIPTION
Modify button css to have a minimum height instead of a fixed height. This should help fix issues where a lot of text is shoved in a small button and bleeds over the border boundary by allowing the button to grow.