### PR TITLE
Increase click area on nav header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.34",
+  "version": "4.0.0-alpha.35",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/components/Nav.scss
+++ b/src/css/components/Nav.scss
@@ -12,6 +12,16 @@
     color: black;
     box-shadow: 4px 1px 10px #00000050;
 
+    .Nav-header {
+      border-bottom: 1px solid color-neutral(2);
+
+      &:hover {
+        cursor: pointer;
+        background-color: color-neutral(2);
+        transition: all ease 200ms
+      }
+    }
+
     a {
       color: black;
     }
@@ -104,6 +114,12 @@
   color: color-neutral(1);
   font-size: 1rem;
   max-height: 65px;
+
+  &:hover {
+    cursor: pointer;
+    background-color: color-primary(8);
+    transition: all ease 200ms;
+  }
 
   .Nav-itemTitle {
     white-space: nowrap;

--- a/src/js/components/Nav/Nav.tsx
+++ b/src/js/components/Nav/Nav.tsx
@@ -204,7 +204,10 @@ const Nav: NavType & { Item: ItemType } = ({
   return (
     <nav className={cname} style={style} {...otherProps}>
       {headerItem ? (
-        <div className="Nav-header u-textSemiBold">
+        <div
+          className="Nav-header u-textSemiBold"
+          onClick={() => setIsFlyoutActive(!isFlyoutActive)}
+        >
           <div className={navHeaderIconClass}>
             <Avatar src={headerItem.image} size="fill" />
           </div>
@@ -212,10 +215,7 @@ const Nav: NavType & { Item: ItemType } = ({
             <span className="Nav-itemTitle">{headerItem.title}</span>
           </div>
           {flyoutSections && (
-            <div
-              className="u-size1of8 Nav-itemTitle u-textRight"
-              onClick={() => setIsFlyoutActive(!isFlyoutActive)}
-            >
+            <div className="u-size1of8 Nav-itemTitle u-textRight">
               <Icon mods="u-fontSizeMd" name="down" />
             </div>
           )}


### PR DESCRIPTION
## Increase click area on nav header

**Story / Task Link**
https://teamsnap.atlassian.net/browse/SO-4680

### Description
This increases the click area for opening the nav flyout.

https://user-images.githubusercontent.com/1085718/119859893-cc566600-bee3-11eb-9b9a-c3d2f2bd1d5f.mov


### What did I do?
- Moved the onClick event to the Nav-header element.
- Added CSS for hover state.
