### PR TITLE
SO-4734: Fixed collapsed menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.47",
+  "version": "4.0.0-alpha.48",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/components/Nav.scss
+++ b/src/css/components/Nav.scss
@@ -88,6 +88,9 @@
     .Nav-itemTitle {
       display: none !important;
     }
+    .Nav-caret {
+      display: none !important;
+    }
     .Icon {
       margin-right: 0;
     }
@@ -96,6 +99,7 @@
       height: 57px;
       margin: 0 auto;
       padding: scaleGrid(2);
+      cursor: default;
     }
 
     .Nav-footer {

--- a/src/js/components/Nav/Nav.tsx
+++ b/src/js/components/Nav/Nav.tsx
@@ -214,7 +214,7 @@ const Nav: NavType & { Item: ItemType } = ({
         {headerItem ? (
           <div
             className="Nav-header u-textSemiBold"
-            onClick={() => setIsFlyoutActive(!isFlyoutActive)}
+            onClick={() => !isCollapsed && setIsFlyoutActive(!isFlyoutActive)}
           >
             <div className={navHeaderIconClass}>
               <Avatar src={headerItem.image} size="fill" />


### PR DESCRIPTION
Found a bug on the collapsed menu where the arrow still shows and still able to open "organization" menu. 

![Screen Shot 2021-07-06 at 9 38 24 AM](https://user-images.githubusercontent.com/3630580/124641877-08b2a580-de44-11eb-89b9-b0e5167a79df.png)

![Screen Shot 2021-07-06 at 9 38 19 AM](https://user-images.githubusercontent.com/3630580/124641895-0bad9600-de44-11eb-9e39-905a66bac870.png)

I've removed the caret and the ability to view the "organizations" menu when the menu is collapsed. 

