### PR TITLE
SO-4786: Fix spacing of paginated tables. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.51",
+  "version": "4.0.0-alpha.52",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -147,6 +147,7 @@ const PaginatedTable: React.FunctionComponent<Props> = ({
                   }
                 },
               }}
+              mods="u-padBottomNone"
             />
           </div>
         ),

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -135,6 +135,7 @@ const PaginatedTable: React.FunctionComponent<Props> = ({
           <div>
             <Checkbox
               name="select-all"
+              mods="u-padBottomNone"
               inputProps={{
                 checked: checkboxState,
                 onClick: () => {
@@ -147,7 +148,6 @@ const PaginatedTable: React.FunctionComponent<Props> = ({
                   }
                 },
               }}
-              mods="u-padBottomNone"
             />
           </div>
         ),


### PR DESCRIPTION
Used `u-padBottomNone` to remove the padding applied from checkbox class. Opted to use utility class rather than using `isInline` prop due to some alignment issues within the table. 