### PR TITLE
SO-5028: Fix some issues with popup component. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.62",
+  "version": "4.0.0-alpha.65",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/css/components/Popup.scss
+++ b/src/css/components/Popup.scss
@@ -59,16 +59,16 @@ $Popup-arrow-borderRadius: 3px;
   left: 50%;
   transform: translateX(-50%) rotate(45deg);
   width: $Popup-arrow-size;
-	height: $Popup-arrow-size;
+  height: $Popup-arrow-size;
   background-color: $Popup-bg-color;
   border-radius: $Popup-arrow-borderRadius 0 $Popup-arrow-borderRadius 0;
-  animation: popInArrow 75ms cubic-bezier(0.2, 0.8, 0.4, 1.0) forwards;
+  animation: popInArrow 75ms cubic-bezier(0.2, 0.8, 0.4, 1) forwards;
 }
 
 // * Bottom square has border and box shadow
 
 .Popup-container::before {
-  top: calc( 100% - #{$Popup-arrow-offset} );
+  top: calc(100% - #{$Popup-arrow-offset});
   border: solid $Popup-border-color $border-width-small;
   box-shadow: $box-shadow-small;
 }
@@ -77,7 +77,7 @@ $Popup-arrow-borderRadius: 3px;
 //   of bottom square that overlay the popup
 
 .Popup-container::after {
-  top: calc( 100% - #{$Popup-arrow-offsetCover} );
+  top: calc(100% - #{$Popup-arrow-offsetCover});
 }
 
 // * .Popup-content
@@ -89,7 +89,7 @@ $Popup-arrow-borderRadius: 3px;
   border: solid $Popup-border-color $border-width-small;
   border-radius: $border-radius-medium;
   box-shadow: $box-shadow-small;
-  animation: popIn 75ms cubic-bezier(0.2, 0.8, 0.4, 1.0) forwards;
+  animation: popIn 75ms cubic-bezier(0.2, 0.8, 0.4, 1) forwards;
 }
 
 // * Overlay modifier
@@ -133,7 +133,7 @@ $Popup-arrow-borderRadius: 3px;
 
   &::before,
   &::after {
-    left: $su-large;
+    left: $su-small;
     transform: translateX(0) rotate(45deg);
   }
 }
@@ -153,7 +153,6 @@ $Popup-arrow-borderRadius: 3px;
   }
 }
 
-
 // * Right modifier
 //
 // * Aligns popover with right side of toggle
@@ -166,7 +165,7 @@ $Popup-arrow-borderRadius: 3px;
   &::before,
   &::after {
     left: auto;
-    right: $su-large;
+    right: $su-small;
     transform: translateX(0) rotate(45deg);
   }
 }
@@ -191,40 +190,36 @@ $Popup-arrow-borderRadius: 3px;
 // * Hover modifier
 //
 // * Allows the user to hover over a popup instead of click
-// * 1. the Popup-content:before creates a small transparent hoverable box that fills the gap between the popup trigger and container  
+// * 1. the Popup-content:before creates a small transparent hoverable box that fills the gap between the popup trigger and container
 // * 2. Since the content: ''; attribute is nested in the hover modifier the Popup-content:before CSS only effects content in a hover modified popup
 
 .Popup--hover {
-
-  .Popup-content:before { // 2
+  .Popup-content:before {
+    // 2
     content: '';
     position: absolute;
     display: block;
   }
-
 }
 
-.Popup-content:before { // 1
+.Popup-content:before {
+  // 1
   height: $su-medium;
   width: 100%;
   left: 0;
-  top: 100%;
 
   .Popup-container--down & {
     top: auto;
     bottom: 100%;
   }
-
 }
 
 .Popup--hover:hover,
-.Popup--hover:focus,
-.Popup--hover:focus-within {
-
-  .Popup-container {
+.Popup--hover:focus {
+  .Popup-container,
+  .Popup-container:focus-within {
     display: block;
   }
-
 }
 
 // * Animations
@@ -236,7 +231,7 @@ $Popup-arrow-borderRadius: 3px;
   }
   100% {
     opacity: 1;
-    transform: scale3d(1.0, 1.0, 1.0);
+    transform: scale3d(1, 1, 1);
   }
 }
 

--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -29,12 +29,91 @@ const actions = [
 
 stories.add('PopupActions', () => {
   return (
-    <PopupAction
-      text="..."
-      actions={actions}
-      direction={['down', 'left']}
-      popupStyle={{ width: '150px' }}
-    />
+    <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+      <div>
+        <PopupAction
+          text="..."
+          actions={actions}
+          direction={['down', 'left']}
+          popupStyle={{ width: '150px' }}
+        />
+      </div>
+    </div>
+  );
+});
+
+stories.add('PopupActions - Down & Left', () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+      <div>
+        <PopupAction
+          text="..."
+          actions={actions}
+          direction={['down', 'left']}
+          popupStyle={{ width: '150px' }}
+        />
+      </div>
+    </div>
+  );
+});
+
+stories.add('PopupActions - Down & Right', () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+      <div>
+        <PopupAction
+          text="..."
+          actions={actions}
+          direction={['down', 'right']}
+          popupStyle={{ width: '150px' }}
+        />
+      </div>
+    </div>
+  );
+});
+
+stories.add('PopupActions - Down & Left Hang', () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+      <div>
+        <PopupAction
+          text="..."
+          actions={actions}
+          direction={['down', 'leftHang']}
+          popupStyle={{ width: '150px' }}
+        />
+      </div>
+    </div>
+  );
+});
+
+stories.add('PopupActions - Down & Right Hang', () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+      <div>
+        <PopupAction
+          text="..."
+          actions={actions}
+          direction={['down', 'rightHang']}
+          popupStyle={{ width: '150px' }}
+        />
+      </div>
+    </div>
+  );
+});
+
+stories.add('PopupActions - Overlay', () => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+      <div>
+        <PopupAction
+          text="..."
+          actions={actions}
+          direction={['overlay']}
+          popupStyle={{ width: '150px' }}
+        />
+      </div>
+    </div>
   );
 });
 
@@ -47,11 +126,17 @@ stories.add('PopupConfirm', () => {
     alert('Good. I dont want to hurt or cry.');
   };
   return (
-    <PopupConfirm
-      onAccept={onAccept}
-      onCancel={onCancel}
-      buttonText="Perform the Culture Club!"
-      popUpText={popupText}
-    />
+    <div
+      style={{ display: 'flex', justifyContent: 'center', minHeight: '100px', paddingTop: '2rem' }}
+    >
+      <div>
+        <PopupConfirm
+          onAccept={onAccept}
+          onCancel={onCancel}
+          buttonText="Perform the Culture Club!"
+          popUpText={popupText}
+        />
+      </div>
+    </div>
   );
 });

--- a/src/js/components/Popup/PopupAction.tsx
+++ b/src/js/components/Popup/PopupAction.tsx
@@ -68,7 +68,9 @@ export default class PopUpAction extends React.Component<Props, State> {
     }
   }
 
-  togglePopup() {
+  togglePopup(e) {
+    e.stopPropagation();
+
     const { isPopupOpen } = this.state;
 
     this.setState({


### PR DESCRIPTION
In safari users are unable to hover over popup menu. For some reason users are also unable to click to button to keep popup menu open.

I've also added a few stories and also corrected some styling for the arrows. `leftHang` and `left` as well as `rightHang` and right were exactly the same thing.

"Hang"
<img width="238" alt="Screen Shot 2021-09-13 at 10 20 36 AM" src="https://user-images.githubusercontent.com/3630580/133131490-f1d9067d-9b58-4cca-9ddd-125996842c60.png">

"No Hang"
<img width="341" alt="Screen Shot 2021-09-13 at 10 20 29 AM" src="https://user-images.githubusercontent.com/3630580/133131524-a5759c73-bcca-42b3-b47a-b98f2d5b28e6.png">

https://teamsnap.atlassian.net/browse/SO-5028