### PR TITLE
Fix is issue with totalItems re-render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.67",
+  "version": "4.0.0-alpha.68",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/ComboBox/Combobox.tsx
+++ b/src/js/components/ComboBox/Combobox.tsx
@@ -103,11 +103,13 @@ const ComboBox = ({
     }
   };
 
-  const clearFilters = () => {
+  const clearFilters = (triggerOnChange = true) => {
     setSelectedFilters([]);
     setHasFilters(false);
-    onChange([]);
     toggleFlyout(false);
+    if (triggerOnChange) {
+      onChange([]);
+    }
   };
 
   const applyFilters = (triggerOnChange = true) => {
@@ -120,7 +122,7 @@ const ComboBox = ({
         onChange(selectedFilters);
       }
     } else {
-      clearFilters();
+      clearFilters(triggerOnChange);
     }
   };
 
@@ -138,7 +140,7 @@ const ComboBox = ({
   // Run this when the flyout visibility
   React.useEffect(() => {
     if (!flyoutVisible) {
-      applyFilters();
+      applyFilters(false);
       sortFilters();
     }
   }, [flyoutVisible]);

--- a/src/js/components/ComboBox/Combobox.tsx
+++ b/src/js/components/ComboBox/Combobox.tsx
@@ -37,9 +37,7 @@ const propTypes = {
       label: PropTypes.string,
     })
   ),
-  selected: PropTypes.arrayOf(
-    PropTypes.any
-  ),
+  selected: PropTypes.arrayOf(PropTypes.any),
   onChange: PropTypes.func,
   className: PropTypes.string,
   mods: PropTypes.string,
@@ -76,7 +74,9 @@ const ComboBox = ({
 
   const shouldShowSearchBar = items.length > 6;
   const filteredItems = searchParam
-    ? uncheckedfilterList.filter((item) => item.label.toLowerCase().includes(searchParam.toLowerCase()))
+    ? uncheckedfilterList.filter((item) =>
+        item.label.toLowerCase().includes(searchParam.toLowerCase())
+      )
     : uncheckedfilterList;
 
   const createLabel = (acc, filter) => {
@@ -104,6 +104,7 @@ const ComboBox = ({
   };
 
   const clearFilters = (triggerOnChange = true) => {
+    console.log('clearFilters()');
     setSelectedFilters([]);
     setHasFilters(false);
     toggleFlyout(false);
@@ -113,6 +114,9 @@ const ComboBox = ({
   };
 
   const applyFilters = (triggerOnChange = true) => {
+    console.log('applyFilters()');
+    console.log('triggerOnChange', triggerOnChange);
+    console.log('selectedFilters', selectedFilters);
     if (selectedFilters.length > 0) {
       setComboLabel(filterList.reduce(createLabel, ''));
       setHasFilters(true);
@@ -127,8 +131,12 @@ const ComboBox = ({
   };
 
   const filtersFromPropsAreDifferent = (fromProps, currentFilters) => {
-    return !!fromProps && (fromProps.length !== 0) && fromProps.some((item) => !(currentFilters || []).includes(item));
-  }
+    return (
+      !!fromProps &&
+      fromProps.length !== 0 &&
+      fromProps.some((item) => !(currentFilters || []).includes(item))
+    );
+  };
 
   // Run this when the props change
   React.useEffect(() => {
@@ -139,8 +147,9 @@ const ComboBox = ({
 
   // Run this when the flyout visibility
   React.useEffect(() => {
+    console.log('flyoutVisible', flyoutVisible);
     if (!flyoutVisible) {
-      applyFilters(false);
+      applyFilters();
       sortFilters();
     }
   }, [flyoutVisible]);

--- a/src/js/components/ComboBox/Combobox.tsx
+++ b/src/js/components/ComboBox/Combobox.tsx
@@ -104,7 +104,6 @@ const ComboBox = ({
   };
 
   const clearFilters = (triggerOnChange = true) => {
-    console.log('clearFilters()');
     setSelectedFilters([]);
     setHasFilters(false);
     toggleFlyout(false);
@@ -114,9 +113,6 @@ const ComboBox = ({
   };
 
   const applyFilters = (triggerOnChange = true) => {
-    console.log('applyFilters()');
-    console.log('triggerOnChange', triggerOnChange);
-    console.log('selectedFilters', selectedFilters);
     if (selectedFilters.length > 0) {
       setComboLabel(filterList.reduce(createLabel, ''));
       setHasFilters(true);
@@ -147,7 +143,6 @@ const ComboBox = ({
 
   // Run this when the flyout visibility
   React.useEffect(() => {
-    console.log('flyoutVisible', flyoutVisible);
     if (!flyoutVisible) {
       applyFilters();
       sortFilters();

--- a/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
@@ -285,8 +285,6 @@ const filterBirthDate = (filter: FilterValue, items: any[]) => {
  * @param filter objec - extra info to provide custom search.
  */
 function loadSearchData({ page, itemsPerPage, filter }) {
-  console.log('loadSearchData');
-  console.log('filter', filter);
   const startIndex = itemsPerPage * page - itemsPerPage;
   return new Promise((resolve) => {
     setTimeout(() => resolve(data), 500);
@@ -324,63 +322,59 @@ function mapData(item) {
   };
 }
 
-// stories.add('Default', () => (
-//   <PaginatedTable
-//     columns={columns}
-//     mapDataToRow={mapData}
-//     loadData={loadData}
-//     defaultItemsPerPage={2}
-//     totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
-//     paginationPlacement={Placement.Bottom}
-//   />
-// ));
-
-// stories.add('Selectable Rows', () => (
-//   <PaginatedTable
-//     columns={columns}
-//     rowsAreSelectable
-//     bulkActions={[
-//       {
-//         label: 'Log Selected',
-//         onSelected: (selected) => {
-//           console.log(selected);
-//         },
-//       },
-//       {
-//         label: 'Alert Selected IDs',
-//         onSelected: (selected) => {
-//           console.log(alert(selected.map((e) => e.id).join(',')));
-//         },
-//       },
-//     ]}
-//     mapDataToRow={mapData}
-//     loadData={loadData}
-//     includeBasicSearch
-//     searchPlaceholder="Search members by name"
-//     defaultItemsPerPage={2}
-//     totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
-//   />
-// ));
-
-// stories.add('Basic Search', () => (
-//   <PaginatedTable
-//     columns={columns}
-//     mapDataToRow={mapData}
-//     loadData={loadSearchData}
-//     defaultItemsPerPage={2}
-//     totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
-//     includeBasicSearch
-//     searchPlaceholder="Search members by name"
-//   />
-// ));
-
 stories.add('Default', () => (
   <PaginatedTable
     columns={columns}
     mapDataToRow={mapData}
+    loadData={loadData}
+    defaultItemsPerPage={2}
+    paginationPlacement={Placement.Bottom}
+  />
+));
+
+stories.add('Selectable Rows', () => (
+  <PaginatedTable
+    columns={columns}
+    rowsAreSelectable
+    bulkActions={[
+      {
+        label: 'Log Selected',
+        onSelected: (selected) => {
+          console.log(selected);
+        },
+      },
+      {
+        label: 'Alert Selected IDs',
+        onSelected: (selected) => {
+          console.log(alert(selected.map((e) => e.id).join(',')));
+        },
+      },
+    ]}
+    mapDataToRow={mapData}
+    loadData={loadData}
+    includeBasicSearch
+    searchPlaceholder="Search members by name"
+    defaultItemsPerPage={2}
+  />
+));
+
+stories.add('Basic Search', () => (
+  <PaginatedTable
+    columns={columns}
+    mapDataToRow={mapData}
     loadData={loadSearchData}
-    defaultItemsPerPage={10}
-    // totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
+    defaultItemsPerPage={2}
+    includeBasicSearch
+    searchPlaceholder="Search members by name"
+  />
+));
+
+stories.add('With Search Filters', () => (
+  <PaginatedTable
+    columns={columns}
+    mapDataToRow={mapData}
+    loadData={loadSearchData}
+    defaultItemsPerPage={2}
     filters={[
       PaginatedTable.Filter('role', 'Participants Role', {
         manager: 'Manager',
@@ -398,7 +392,7 @@ stories.add('Default', () => (
         other: 'Other',
         unknown: 'Unknown',
       }),
-      // PaginatedTable.Filter('birthdate', 'Participants Birthdate', undefined, 'date'),
+      PaginatedTable.Filter('birthdate', 'Participants Birthdate', undefined, 'date'),
     ]}
     paginationPlacement={Placement.Bottom}
     includeBasicSearch

--- a/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.stories.tsx
@@ -285,6 +285,8 @@ const filterBirthDate = (filter: FilterValue, items: any[]) => {
  * @param filter objec - extra info to provide custom search.
  */
 function loadSearchData({ page, itemsPerPage, filter }) {
+  console.log('loadSearchData');
+  console.log('filter', filter);
   const startIndex = itemsPerPage * page - itemsPerPage;
   return new Promise((resolve) => {
     setTimeout(() => resolve(data), 500);
@@ -322,63 +324,63 @@ function mapData(item) {
   };
 }
 
+// stories.add('Default', () => (
+//   <PaginatedTable
+//     columns={columns}
+//     mapDataToRow={mapData}
+//     loadData={loadData}
+//     defaultItemsPerPage={2}
+//     totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
+//     paginationPlacement={Placement.Bottom}
+//   />
+// ));
+
+// stories.add('Selectable Rows', () => (
+//   <PaginatedTable
+//     columns={columns}
+//     rowsAreSelectable
+//     bulkActions={[
+//       {
+//         label: 'Log Selected',
+//         onSelected: (selected) => {
+//           console.log(selected);
+//         },
+//       },
+//       {
+//         label: 'Alert Selected IDs',
+//         onSelected: (selected) => {
+//           console.log(alert(selected.map((e) => e.id).join(',')));
+//         },
+//       },
+//     ]}
+//     mapDataToRow={mapData}
+//     loadData={loadData}
+//     includeBasicSearch
+//     searchPlaceholder="Search members by name"
+//     defaultItemsPerPage={2}
+//     totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
+//   />
+// ));
+
+// stories.add('Basic Search', () => (
+//   <PaginatedTable
+//     columns={columns}
+//     mapDataToRow={mapData}
+//     loadData={loadSearchData}
+//     defaultItemsPerPage={2}
+//     totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
+//     includeBasicSearch
+//     searchPlaceholder="Search members by name"
+//   />
+// ));
+
 stories.add('Default', () => (
   <PaginatedTable
     columns={columns}
     mapDataToRow={mapData}
-    loadData={loadData}
-    defaultItemsPerPage={2}
-    totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
-    paginationPlacement={Placement.Bottom}
-  />
-));
-
-stories.add('Selectable Rows', () => (
-  <PaginatedTable
-    columns={columns}
-    rowsAreSelectable
-    bulkActions={[
-      {
-        label: 'Log Selected',
-        onSelected: (selected) => {
-          console.log(selected);
-        },
-      },
-      {
-        label: 'Alert Selected IDs',
-        onSelected: (selected) => {
-          console.log(alert(selected.map((e) => e.id).join(',')));
-        },
-      },
-    ]}
-    mapDataToRow={mapData}
-    loadData={loadData}
-    includeBasicSearch
-    searchPlaceholder="Search members by name"
-    defaultItemsPerPage={2}
-    totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
-  />
-));
-
-stories.add('Basic Search', () => (
-  <PaginatedTable
-    columns={columns}
-    mapDataToRow={mapData}
     loadData={loadSearchData}
-    defaultItemsPerPage={2}
-    totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
-    includeBasicSearch
-    searchPlaceholder="Search members by name"
-  />
-));
-
-stories.add('With Search Filters', () => (
-  <PaginatedTable
-    columns={columns}
-    mapDataToRow={mapData}
-    loadData={loadSearchData}
-    defaultItemsPerPage={2}
-    totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
+    defaultItemsPerPage={10}
+    // totalItems={data.length} // you'll likely need to calculate this in your component by inspecting the http response.
     filters={[
       PaginatedTable.Filter('role', 'Participants Role', {
         manager: 'Manager',
@@ -396,7 +398,7 @@ stories.add('With Search Filters', () => (
         other: 'Other',
         unknown: 'Unknown',
       }),
-      PaginatedTable.Filter('birthdate', 'Participants Birthdate', undefined, 'date'),
+      // PaginatedTable.Filter('birthdate', 'Participants Birthdate', undefined, 'date'),
     ]}
     paginationPlacement={Placement.Bottom}
     includeBasicSearch

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -62,7 +62,7 @@ const propTypes = {
   paginationPlacement: PropTypes.oneOf([Placement.Top, Placement.Bottom]),
   rowsAreSelectable: PropTypes.bool,
   searchPlaceholder: PropTypes.string,
-  totalItems: PropTypes.number.isRequired,
+  // totalItems: PropTypes.number.isRequired,
   defaultSort: PropTypes.string,
 };
 
@@ -76,7 +76,12 @@ const Filter = (
     const ctx = React.useContext(FilterContext);
 
     const onChange = (values) => {
-      ctx.setActiveFilters({ ...ctx.activeFilters, [fieldName]: values });
+      if (values.length > 0) {
+        ctx.setActiveFilters({ ...ctx.activeFilters, [fieldName]: values });
+      } else {
+        delete ctx.activeFilters[fieldName];
+        ctx.setActiveFilters({ ...ctx.activeFilters });
+      }
     };
 
     return type === 'select' ? (
@@ -108,7 +113,7 @@ const PaginatedTable: PaginatedTableProps = ({
   mapDataToRow,
   defaultPage,
   defaultItemsPerPage,
-  totalItems,
+  // totalItems,
   hideRowsSelect,
   rowsAreSelectable = false,
   bulkActions,
@@ -128,6 +133,7 @@ const PaginatedTable: PaginatedTableProps = ({
     defaultItemsPerPage || 10,
     defaultPage || 1
   );
+  const [totalItems, setTotalItems] = React.useState(null);
   const [dataSet, setDataSet] = React.useState([]);
   const [sortName, setSortName] = React.useState('');
   const [sortAscending, setSortAscending] = React.useState(false);
@@ -161,6 +167,7 @@ const PaginatedTable: PaginatedTableProps = ({
       filter: includeBasicSearch || activeFilters ? { searchTerm, ...activeFilters } : null,
     }).then((data) => {
       setDataSet(data);
+      setTotalItems(data.length);
       setIsLoading(false);
     });
   }, [itemsPerPage, currentPage, sortName, sortAscending, searchTerm, activeFilters]);
@@ -283,7 +290,9 @@ const PaginatedTable: PaginatedTableProps = ({
     <div>
       <Button
         isActive={filterOpen}
-        onClick={() => setFilterOpen(!filterOpen)}
+        onClick={() => {
+          setFilterOpen(!filterOpen);
+        }}
         mods="u-spaceLeftSm"
         icon="wrench"
       >
@@ -292,7 +301,7 @@ const PaginatedTable: PaginatedTableProps = ({
     </div>
   );
 
-  const defaultSortStr =  sortName.length ? `${sortAscending ? '-' : ''}${sortName}` : defaultSort;
+  const defaultSortStr = sortName.length ? `${sortAscending ? '-' : ''}${sortName}` : defaultSort;
 
   return (
     <div className="Grid">
@@ -337,27 +346,29 @@ const PaginatedTable: PaginatedTableProps = ({
         {shouldPaginateAtTop && paginationItems}
         {!shouldPaginateAtTop && filterButton}
       </div>
-        {filterOpen && (
-          <Panel mods="u-padSm u-spaceTopSm u-borderNeutral4 u-bgNeutral1 Grid-cell">
-            <FilterContext.Provider value={{ activeFilters, setActiveFilters }}>
-              {filters.map((Item, index) => (
-                <Item key={index} isLast={index === filters.length - 1} />
-              ))}
-            </FilterContext.Provider>
-          </Panel>
-        )}
-        <div className="Grid-cell u-spaceTopSm">
-          <Table
-            columns={cols}
-            rows={rows}
-            defaultSort={defaultSortStr}
-            externalSortingFunction={(name, ascending) => {
-              setSortName(name);
-              setSortAscending(ascending);
-            }}
-            isLoading={isLoading}
-          />
-        </div>
+      <Panel
+        mods={`${
+          filterOpen ? '' : 'u-hidden'
+        } u-padSm u-spaceTopSm u-borderNeutral4 u-bgNeutral1 Grid-cell`}
+      >
+        <FilterContext.Provider value={{ activeFilters, setActiveFilters }}>
+          {filters.map((Item, index) => (
+            <Item key={index} isLast={index === filters.length - 1} />
+          ))}
+        </FilterContext.Provider>
+      </Panel>
+      <div className="Grid-cell u-spaceTopSm">
+        <Table
+          columns={cols}
+          rows={rows}
+          defaultSort={defaultSortStr}
+          externalSortingFunction={(name, ascending) => {
+            setSortName(name);
+            setSortAscending(ascending);
+          }}
+          isLoading={isLoading}
+        />
+      </div>
       {(paginationPlacement === Placement.Bottom || !shouldPaginateAtTop) && paginationItems}
     </div>
   );

--- a/src/js/components/Table/Paginated/PaginatedTable.tsx
+++ b/src/js/components/Table/Paginated/PaginatedTable.tsx
@@ -337,12 +337,13 @@ const PaginatedTable: PaginatedTableProps = ({
         {shouldPaginateAtTop && paginationItems}
         {!shouldPaginateAtTop && filterButton}
       </div>
-      <FilterContext.Provider value={{ activeFilters, setActiveFilters }}>
         {filterOpen && (
           <Panel mods="u-padSm u-spaceTopSm u-borderNeutral4 u-bgNeutral1 Grid-cell">
-            {filters.map((Item, index) => (
-              <Item key={index} isLast={index === filters.length - 1} />
-            ))}
+            <FilterContext.Provider value={{ activeFilters, setActiveFilters }}>
+              {filters.map((Item, index) => (
+                <Item key={index} isLast={index === filters.length - 1} />
+              ))}
+            </FilterContext.Provider>
           </Panel>
         )}
         <div className="Grid-cell u-spaceTopSm">
@@ -357,7 +358,6 @@ const PaginatedTable: PaginatedTableProps = ({
             isLoading={isLoading}
           />
         </div>
-      </FilterContext.Provider>
       {(paginationPlacement === Placement.Bottom || !shouldPaginateAtTop) && paginationItems}
     </div>
   );


### PR DESCRIPTION
<img width="466" alt="Screen Shot 2021-09-20 at 9 23 41 AM" src="https://user-images.githubusercontent.com/3630580/134038327-6762ebc5-99cb-432d-b959-8532fb1651dc.png">

In TeamSnap SPAs in the `loadData` function when we call `setTotalItems(members.length);` on line 68 the PaginatedTable re-renders again with an empty filter list which is incorrect. In order to fix that issue I'm thinking it may be a better idea to set totally items within the PaginatedTable component itself since in the `loadData` function returns a list of items, in the PaginatedTable we could set `totalItems` from the length of that list. 

I've also made a change to the "Filter" toggle button to conditionally add `u-hidden` to the filters section instead of the button rendering the filters and combobox when filters are toggle to be shown. This will make it so that the filters persist when the filters shown or hidden. 
