### PR TITLE
Full bleed modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react": "^17.0.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
+    "react-dom": "^17.0.1",
     "react-test-renderer": "^17.0.2",
     "sass": "^1.35.1",
     "sass-loader": "^10.1.1",
@@ -111,8 +112,7 @@
     "core-js": "^3.1.4",
     "gulp-rename": "^2.0.0",
     "lodash": "^4.17.21",
-    "prop-types": "^15.6.1",
-    "react-dom": "^17.0.1"
+    "prop-types": "^15.6.1"
   },
   "peerDependencies": {
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "react": "^17.0.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
-    "react-dom": "^17.0.1",
     "react-test-renderer": "^17.0.2",
     "sass": "^1.35.1",
     "sass-loader": "^10.1.1",
@@ -112,7 +111,8 @@
     "core-js": "^3.1.4",
     "gulp-rename": "^2.0.0",
     "lodash": "^4.17.21",
-    "prop-types": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "react-dom": "^17.0.1"
   },
   "peerDependencies": {
     "prettier": "^2.3.2",

--- a/src/css/components/Modal.scss
+++ b/src/css/components/Modal.scss
@@ -18,20 +18,44 @@
 .Modal-content {
   position: fixed;
   background: white;
+  width: 80%;
   min-width: 50%;
   height: auto;
+  max-height: 90vh;
+  overflow: scroll;
   top: 50%;
   left: 50%;
   transform: translate(-50%,-50%);
   border-radius: 10px;
 }
 
-.Modal--open {
-  display: block;
+.Modal--full-bleed {
+  background: white;
+
+  .Modal-content {
+    position: relative;
+    width: auto;
+    top: auto;
+    left: auto;
+    border-radius: none;
+    transform: none;
+  }
 }
 
-.Modal--closed {
-  display: none;
+// Prevent the body from scrolling while the modal is open.
+body.Modal--open {
+  overflow: hidden;
+  height: 100%;
+}
+
+.Modal {
+  &.Modal--open {
+    display: block;
+  }
+
+  &.Modal--closed {
+    display: none;
+  }
 }
 
 .Modal-header,
@@ -43,4 +67,10 @@
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
+}
+
+@media screen and (min-width: 480px) {
+  .Modal-content {
+    width: 50%;
+  }
 }

--- a/src/js/components/Modal/Modal.stories.tsx
+++ b/src/js/components/Modal/Modal.stories.tsx
@@ -21,6 +21,7 @@ stories.add('Default', () => {
       <Modal
         heading={<div className="u-textCenter">Sending</div>}
         show={sending}
+        showClose
         closeFn={() => setSending(false)}
       >
         <Loader type="spin" text="Sending" message="Some really long message here" />
@@ -66,6 +67,170 @@ stories.add('Long Body Text', () => {
         allowOverlayClose
         closeFn={() => setSending(false)}
       >
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent
+          libero. Sed cursus ante <b>Integer</b> dapibus diam. Sed nisi. Nulla quis sem at{' '}
+          <i>Lorem</i> nibh elementum imperdiet. Duis <b>quis</b> sagittis ipsum. Praesent mauris.
+          Fusce nec tellus sed augue semper porta. Mauris <b>Praesent</b> massa. Vestibulum{' '}
+          <i>sagittis</i> lacinia arcu eget nulla. <i>at</i> Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos. Curabitur <i>massa.</i> sodales
+          ligula in <i>lacinia</i> libero. Sed dignissim lacinia nunc. <i>litora</i> Curabitur
+          tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas{' '}
+          <b>Aenean</b> mattis. <b>Aenean</b> Sed convallis tristique sem. <i>Curabitur</i> Proin ut
+          ligula vel nunc egestas <i>dolor.</i> porttitor. Morbi lectus risus, <i>sem</i> iaculis
+          vel, suscipit quis, luctus non, massa. Fusce ac <i>dolor.</i> turpis quis ligula lacinia
+          aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in,{' '}
+          <b>aliquet.</b> nibh. <b>ipsum.</b> Quisque volutpat condimentum velit. Class aptent
+          taciti sociosqu ad litora torquent <i>ipsum.</i> per conubia nostra, per <i>in,</i>{' '}
+          inceptos himenaeos. Nam nec <b>litora</b> ante. Sed lacinia, <b>litora</b> urna{' '}
+          <i>nibh.</i> non tincidunt mattis, tortor neque adipiscing diam, a cursus ipsum ante quis
+          turpis. Nulla facilisi. Ut fringilla. Suspendisse <b>ipsum</b> potenti. Nunc feugiat mi a
+          tellus <b>turpis.</b> consequat imperdiet. Vestibulum sapien. Proin quam. Etiam ultrices.{' '}
+          <b>consequat</b> Suspendisse in justo eu <b>sapien.</b> magna luctus <i>turpis.</i>{' '}
+          suscipit. Sed lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+          pharetra auctor, sem massa <b>lacus</b> mattis sem, at interdum magna augue eget diam.
+          Vestibulum <i>lectus.</i> ante <b>at</b> ipsum <i>Quisque</i> primis <b>augue</b> in
+          faucibus orci luctus et ultrices posuere cubilia Curae; Morbi <i>at</i> lacinia{' '}
+          <i>eget</i> molestie dui. Praesent blandit dolor. Sed non quam. In vel <b>lacinia</b> mi
+          sit amet augue congue elementum. Morbi in ipsum sit amet pede facilisis laoreet. Donec
+          lacus <b>augue</b> nunc, <b>sit</b> viverra nec.
+        </p>
+
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent
+          libero. Sed cursus ante <b>Integer</b> dapibus diam. Sed nisi. Nulla quis sem at{' '}
+          <i>Lorem</i> nibh elementum imperdiet. Duis <b>quis</b> sagittis ipsum. Praesent mauris.
+          Fusce nec tellus sed augue semper porta. Mauris <b>Praesent</b> massa. Vestibulum{' '}
+          <i>sagittis</i> lacinia arcu eget nulla. <i>at</i> Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos. Curabitur <i>massa.</i> sodales
+          ligula in <i>lacinia</i> libero. Sed dignissim lacinia nunc. <i>litora</i> Curabitur
+          tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas{' '}
+          <b>Aenean</b> mattis. <b>Aenean</b> Sed convallis tristique sem. <i>Curabitur</i> Proin ut
+          ligula vel nunc egestas <i>dolor.</i> porttitor. Morbi lectus risus, <i>sem</i> iaculis
+          vel, suscipit quis, luctus non, massa. Fusce ac <i>dolor.</i> turpis quis ligula lacinia
+          aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in,{' '}
+          <b>aliquet.</b> nibh. <b>ipsum.</b> Quisque volutpat condimentum velit. Class aptent
+          taciti sociosqu ad litora torquent <i>ipsum.</i> per conubia nostra, per <i>in,</i>{' '}
+          inceptos himenaeos. Nam nec <b>litora</b> ante. Sed lacinia, <b>litora</b> urna{' '}
+          <i>nibh.</i> non tincidunt mattis, tortor neque adipiscing diam, a cursus ipsum ante quis
+          turpis. Nulla facilisi. Ut fringilla. Suspendisse <b>ipsum</b> potenti. Nunc feugiat mi a
+          tellus <b>turpis.</b> consequat imperdiet. Vestibulum sapien. Proin quam. Etiam ultrices.{' '}
+          <b>consequat</b> Suspendisse in justo eu <b>sapien.</b> magna luctus <i>turpis.</i>{' '}
+          suscipit. Sed lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+          pharetra auctor, sem massa <b>lacus</b> mattis sem, at interdum magna augue eget diam.
+          Vestibulum <i>lectus.</i> ante <b>at</b> ipsum <i>Quisque</i> primis <b>augue</b> in
+          faucibus orci luctus et ultrices posuere cubilia Curae; Morbi <i>at</i> lacinia{' '}
+          <i>eget</i> molestie dui. Praesent blandit dolor. Sed non quam. In vel <b>lacinia</b> mi
+          sit amet augue congue elementum. Morbi in ipsum sit amet pede facilisis laoreet. Donec
+          lacus <b>augue</b> nunc, <b>sit</b> viverra nec.
+        </p>
+
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent
+          libero. Sed cursus ante <b>Integer</b> dapibus diam. Sed nisi. Nulla quis sem at{' '}
+          <i>Lorem</i> nibh elementum imperdiet. Duis <b>quis</b> sagittis ipsum. Praesent mauris.
+          Fusce nec tellus sed augue semper porta. Mauris <b>Praesent</b> massa. Vestibulum{' '}
+          <i>sagittis</i> lacinia arcu eget nulla. <i>at</i> Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos. Curabitur <i>massa.</i> sodales
+          ligula in <i>lacinia</i> libero. Sed dignissim lacinia nunc. <i>litora</i> Curabitur
+          tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas{' '}
+          <b>Aenean</b> mattis. <b>Aenean</b> Sed convallis tristique sem. <i>Curabitur</i> Proin ut
+          ligula vel nunc egestas <i>dolor.</i> porttitor. Morbi lectus risus, <i>sem</i> iaculis
+          vel, suscipit quis, luctus non, massa. Fusce ac <i>dolor.</i> turpis quis ligula lacinia
+          aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in,{' '}
+          <b>aliquet.</b> nibh. <b>ipsum.</b> Quisque volutpat condimentum velit. Class aptent
+          taciti sociosqu ad litora torquent <i>ipsum.</i> per conubia nostra, per <i>in,</i>{' '}
+          inceptos himenaeos. Nam nec <b>litora</b> ante. Sed lacinia, <b>litora</b> urna{' '}
+          <i>nibh.</i> non tincidunt mattis, tortor neque adipiscing diam, a cursus ipsum ante quis
+          turpis. Nulla facilisi. Ut fringilla. Suspendisse <b>ipsum</b> potenti. Nunc feugiat mi a
+          tellus <b>turpis.</b> consequat imperdiet. Vestibulum sapien. Proin quam. Etiam ultrices.{' '}
+          <b>consequat</b> Suspendisse in justo eu <b>sapien.</b> magna luctus <i>turpis.</i>{' '}
+          suscipit. Sed lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+          pharetra auctor, sem massa <b>lacus</b> mattis sem, at interdum magna augue eget diam.
+          Vestibulum <i>lectus.</i> ante <b>at</b> ipsum <i>Quisque</i> primis <b>augue</b> in
+          faucibus orci luctus et ultrices posuere cubilia Curae; Morbi <i>at</i> lacinia{' '}
+          <i>eget</i> molestie dui. Praesent blandit dolor. Sed non quam. In vel <b>lacinia</b> mi
+          sit amet augue congue elementum. Morbi in ipsum sit amet pede facilisis laoreet. Donec
+          lacus <b>augue</b> nunc, <b>sit</b> viverra nec.
+        </p>
+      </Modal>
+    </>
+  );
+});
+
+stories.add('Full bleed', () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <>
+      <Button label="Test Modal" onClick={() => setIsOpen(true)} />
+
+      <Modal
+        heading="Full bleed"
+        show={isOpen}
+        showClose={true}
+        allowOverlayClose={false}
+        closeFn={() => setIsOpen(false)}
+        isFullBleed
+      >
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent
+          libero. Sed cursus ante <b>Integer</b> dapibus diam. Sed nisi. Nulla quis sem at{' '}
+          <i>Lorem</i> nibh elementum imperdiet. Duis <b>quis</b> sagittis ipsum. Praesent mauris.
+          Fusce nec tellus sed augue semper porta. Mauris <b>Praesent</b> massa. Vestibulum{' '}
+          <i>sagittis</i> lacinia arcu eget nulla. <i>at</i> Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos. Curabitur <i>massa.</i> sodales
+          ligula in <i>lacinia</i> libero. Sed dignissim lacinia nunc. <i>litora</i> Curabitur
+          tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas{' '}
+          <b>Aenean</b> mattis. <b>Aenean</b> Sed convallis tristique sem. <i>Curabitur</i> Proin ut
+          ligula vel nunc egestas <i>dolor.</i> porttitor. Morbi lectus risus, <i>sem</i> iaculis
+          vel, suscipit quis, luctus non, massa. Fusce ac <i>dolor.</i> turpis quis ligula lacinia
+          aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in,{' '}
+          <b>aliquet.</b> nibh. <b>ipsum.</b> Quisque volutpat condimentum velit. Class aptent
+          taciti sociosqu ad litora torquent <i>ipsum.</i> per conubia nostra, per <i>in,</i>{' '}
+          inceptos himenaeos. Nam nec <b>litora</b> ante. Sed lacinia, <b>litora</b> urna{' '}
+          <i>nibh.</i> non tincidunt mattis, tortor neque adipiscing diam, a cursus ipsum ante quis
+          turpis. Nulla facilisi. Ut fringilla. Suspendisse <b>ipsum</b> potenti. Nunc feugiat mi a
+          tellus <b>turpis.</b> consequat imperdiet. Vestibulum sapien. Proin quam. Etiam ultrices.{' '}
+          <b>consequat</b> Suspendisse in justo eu <b>sapien.</b> magna luctus <i>turpis.</i>{' '}
+          suscipit. Sed lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+          pharetra auctor, sem massa <b>lacus</b> mattis sem, at interdum magna augue eget diam.
+          Vestibulum <i>lectus.</i> ante <b>at</b> ipsum <i>Quisque</i> primis <b>augue</b> in
+          faucibus orci luctus et ultrices posuere cubilia Curae; Morbi <i>at</i> lacinia{' '}
+          <i>eget</i> molestie dui. Praesent blandit dolor. Sed non quam. In vel <b>lacinia</b> mi
+          sit amet augue congue elementum. Morbi in ipsum sit amet pede facilisis laoreet. Donec
+          lacus <b>augue</b> nunc, <b>sit</b> viverra nec.
+        </p>
+
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent
+          libero. Sed cursus ante <b>Integer</b> dapibus diam. Sed nisi. Nulla quis sem at{' '}
+          <i>Lorem</i> nibh elementum imperdiet. Duis <b>quis</b> sagittis ipsum. Praesent mauris.
+          Fusce nec tellus sed augue semper porta. Mauris <b>Praesent</b> massa. Vestibulum{' '}
+          <i>sagittis</i> lacinia arcu eget nulla. <i>at</i> Class aptent taciti sociosqu ad litora
+          torquent per conubia nostra, per inceptos himenaeos. Curabitur <i>massa.</i> sodales
+          ligula in <i>lacinia</i> libero. Sed dignissim lacinia nunc. <i>litora</i> Curabitur
+          tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas{' '}
+          <b>Aenean</b> mattis. <b>Aenean</b> Sed convallis tristique sem. <i>Curabitur</i> Proin ut
+          ligula vel nunc egestas <i>dolor.</i> porttitor. Morbi lectus risus, <i>sem</i> iaculis
+          vel, suscipit quis, luctus non, massa. Fusce ac <i>dolor.</i> turpis quis ligula lacinia
+          aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in,{' '}
+          <b>aliquet.</b> nibh. <b>ipsum.</b> Quisque volutpat condimentum velit. Class aptent
+          taciti sociosqu ad litora torquent <i>ipsum.</i> per conubia nostra, per <i>in,</i>{' '}
+          inceptos himenaeos. Nam nec <b>litora</b> ante. Sed lacinia, <b>litora</b> urna{' '}
+          <i>nibh.</i> non tincidunt mattis, tortor neque adipiscing diam, a cursus ipsum ante quis
+          turpis. Nulla facilisi. Ut fringilla. Suspendisse <b>ipsum</b> potenti. Nunc feugiat mi a
+          tellus <b>turpis.</b> consequat imperdiet. Vestibulum sapien. Proin quam. Etiam ultrices.{' '}
+          <b>consequat</b> Suspendisse in justo eu <b>sapien.</b> magna luctus <i>turpis.</i>{' '}
+          suscipit. Sed lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+          pharetra auctor, sem massa <b>lacus</b> mattis sem, at interdum magna augue eget diam.
+          Vestibulum <i>lectus.</i> ante <b>at</b> ipsum <i>Quisque</i> primis <b>augue</b> in
+          faucibus orci luctus et ultrices posuere cubilia Curae; Morbi <i>at</i> lacinia{' '}
+          <i>eget</i> molestie dui. Praesent blandit dolor. Sed non quam. In vel <b>lacinia</b> mi
+          sit amet augue congue elementum. Morbi in ipsum sit amet pede facilisis laoreet. Donec
+          lacus <b>augue</b> nunc, <b>sit</b> viverra nec.
+        </p>
+
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent
           libero. Sed cursus ante <b>Integer</b> dapibus diam. Sed nisi. Nulla quis sem at{' '}

--- a/src/js/components/Modal/Modal.stories.tsx
+++ b/src/js/components/Modal/Modal.stories.tsx
@@ -168,7 +168,7 @@ stories.add('Full bleed', () => {
       <Modal
         heading="Full bleed"
         show={isOpen}
-        showClose={true}
+        showClose
         allowOverlayClose={false}
         closeFn={() => setIsOpen(false)}
         isFullBleed

--- a/src/js/components/Modal/Modal.tsx
+++ b/src/js/components/Modal/Modal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { createPortal } from 'react-dom';
 import { Button } from '../Button';
 
 export interface Props {
@@ -11,7 +10,6 @@ export interface Props {
   style?: React.CSSProperties;
   closeFn?: () => void;
   isFullBleed?: boolean;
-  fullBleedRootNode?: HTMLElement;
 }
 
 const Modal: React.FC<Props> = ({
@@ -23,7 +21,6 @@ const Modal: React.FC<Props> = ({
   allowOverlayClose,
   style,
   isFullBleed,
-  fullBleedRootNode,
 }: Props) => {
   React.useEffect(() => {
     if (allowOverlayClose) {
@@ -47,7 +44,7 @@ const Modal: React.FC<Props> = ({
     document.body.classList.toggle('Modal--open', show);
   }, [show]);
 
-  let component = (
+  return (
     <div
       className={`Modal ${show ? 'Modal--open' : 'Modal--closed'} ${
         isFullBleed ? 'Modal--full-bleed' : ''
@@ -73,13 +70,6 @@ const Modal: React.FC<Props> = ({
       </div>
     </div>
   );
-
-  if (isFullBleed) {
-    const rootNode = fullBleedRootNode || document.body;
-    component = createPortal(component, rootNode);
-  }
-
-  return component;
 };
 
 export default Modal;

--- a/src/js/components/Modal/Modal.tsx
+++ b/src/js/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import { Button } from '../Button';
 
 export interface Props {
@@ -47,7 +47,7 @@ const Modal: React.FC<Props> = ({
     document.body.classList.toggle('Modal--open', show);
   }, [show]);
 
-  const component = (
+  let component = (
     <div
       className={`Modal ${show ? 'Modal--open' : 'Modal--closed'} ${
         isFullBleed ? 'Modal--full-bleed' : ''
@@ -76,10 +76,10 @@ const Modal: React.FC<Props> = ({
 
   if (isFullBleed) {
     const rootNode = fullBleedRootNode || document.body;
-    return ReactDOM.createPortal(component, rootNode);
-  } else {
-    return component;
+    component = createPortal(component, rootNode);
   }
+
+  return component;
 };
 
 export default Modal;

--- a/src/js/components/Modal/Modal.tsx
+++ b/src/js/components/Modal/Modal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import { Button } from '../Button';
 
 export interface Props {
@@ -9,6 +10,8 @@ export interface Props {
   allowOverlayClose?: boolean;
   style?: React.CSSProperties;
   closeFn?: () => void;
+  isFullBleed?: boolean;
+  fullBleedRootNode?: HTMLElement;
 }
 
 const Modal: React.FC<Props> = ({
@@ -19,6 +22,8 @@ const Modal: React.FC<Props> = ({
   closeFn,
   allowOverlayClose,
   style,
+  isFullBleed,
+  fullBleedRootNode,
 }: Props) => {
   React.useEffect(() => {
     if (allowOverlayClose) {
@@ -38,9 +43,17 @@ const Modal: React.FC<Props> = ({
     return () => {};
   }, []);
 
-  return (
-    <div className={`Modal ${show ? 'Modal--open' : 'Modal--closed'}`}>
-      <div className="Modal-content u-posRelative" style={{ width: '50%', ...(style || {}) }}>
+  React.useEffect(() => {
+    document.body.classList.toggle('Modal--open', show);
+  }, [show]);
+
+  const component = (
+    <div
+      className={`Modal ${show ? 'Modal--open' : 'Modal--closed'} ${
+        isFullBleed ? 'Modal--full-bleed' : ''
+      }`}
+    >
+      <div className="Modal-content u-posRelative" style={{ ...(style || {}) }}>
         <div className="Modal-header u-flex u-flexJustifyBetween">
           <div className="u-sizeFill">
             <h2>{heading}</h2>
@@ -60,6 +73,13 @@ const Modal: React.FC<Props> = ({
       </div>
     </div>
   );
+
+  if (isFullBleed) {
+    const rootNode = fullBleedRootNode || document.body;
+    return ReactDOM.createPortal(component, rootNode);
+  } else {
+    return component;
+  }
 };
 
 export default Modal;


### PR DESCRIPTION
This commit adds a "full bleed" feature for modals. This feature leans on React Portals to mount the modal component onto either the document's body element (default) or any other node passed down as a prop. When enabled, full bleed mode creates a modal at the top of the DOM (direct descendant of the BODY element) that is 100vw and 100vh.

Also included is a mechanism to prevent the page from scrolling (behind the modal) when the modal is open. It adds scrollability to modals with content taller than the available viewport.