### PR TITLE
Add id props for form input components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.89",
+  "version": "4.0.0-alpha.90",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Checkbox/Checkbox.tsx
+++ b/src/js/components/Checkbox/Checkbox.tsx
@@ -17,6 +17,7 @@ import { InputControl } from '../InputControl';
 import { CheckboxStates } from '../../types';
 
 const propTypes = {
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
   inputProps: PropTypes.any,

--- a/src/js/components/CheckboxPill/CheckboxPill.tsx
+++ b/src/js/components/CheckboxPill/CheckboxPill.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Grid } from '../Grid';
 import { Cell } from '../Cell';
-import { Pill } from '../Pill';
+import { Pill, PillStatus } from '../Pill';
 import { Field } from '../Field';
 
 const CheckboxPill = () => {
@@ -14,7 +14,7 @@ const CheckboxPill = () => {
   return (
     <Grid>
       <Cell>
-        <Pill align="center">
+        <Pill align="center" status={checked ? PillStatus.ACTIVE : null}>
           <Field
             formFieldProps={{
               checked,

--- a/src/js/components/Field/Field.stories.tsx
+++ b/src/js/components/Field/Field.stories.tsx
@@ -361,7 +361,8 @@ export const Radios = () => {
             setFavoritePet('cat');
           },
         }}
-        name="Cats"
+        id="favorite-pet-cats"
+        name="favorite-pet"
       />
       <Field
         isInline
@@ -374,7 +375,8 @@ export const Radios = () => {
             setFavoritePet('dog');
           },
         }}
-        name="Dogs"
+        id="favorite-pet-dogs"
+        name="favorite-pet"
       />
       <Field
         isDisabled

--- a/src/js/components/Field/Field.tsx
+++ b/src/js/components/Field/Field.tsx
@@ -50,6 +50,7 @@ const inputShape = PropTypes.shape({
 const fieldPropTypes = {
   type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date']).isRequired,
   formFieldProps: PropTypes.oneOfType([checkboxShape, inputShape]),
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   caption: PropTypes.string,
@@ -67,6 +68,7 @@ type FieldProps = PropTypes.InferProps<typeof fieldPropTypes>;
 
 const Field = ({
   type,
+  id,
   name,
   label,
   caption,
@@ -107,6 +109,7 @@ const Field = ({
           case 'checkbox':
             return (
               <Checkbox
+                id={id}
                 name={name}
                 inputProps={{
                   checked,
@@ -120,6 +123,7 @@ const Field = ({
           case 'radio':
             return (
               <Radio
+                id={id}
                 name={name}
                 inputProps={{
                   checked,
@@ -133,6 +137,7 @@ const Field = ({
           default:
             return (
               <Input
+                id={id}
                 size={size}
                 placeholder={placeholder}
                 name={name}

--- a/src/js/components/Input/Input.tsx
+++ b/src/js/components/Input/Input.tsx
@@ -34,6 +34,7 @@ const propTypes = {
   rightIcon: PropTypes.node,
   inputProps: PropTypes.object,
   mods: PropTypes.string,
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   otherProps: PropTypes.object,
   placeholder: PropTypes.string,
@@ -54,6 +55,7 @@ const Input = ({
   inputProps,
   leftIcon,
   mods,
+  id,
   name,
   otherProps,
   placeholder,
@@ -76,12 +78,15 @@ const Input = ({
     'u-flex',
     mods
   );
+
+  id = id || name;
+
   return (
     <div className={inputClasses} style={style} data-testid={testId} {...otherProps}>
       {leftIcon && <div className="InputGroup-icon--left InputGroup-icon">{leftIcon}</div>}
       <input
         disabled={isDisabled}
-        id={name}
+        id={id}
         name={name}
         type={type}
         placeholder={placeholder}

--- a/src/js/components/InputControl/InputControl.tsx
+++ b/src/js/components/InputControl/InputControl.tsx
@@ -16,6 +16,7 @@ import { getClassName } from '../../utils/helpers';
 import { CheckboxStates } from '../../types';
 
 const propTypes = {
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   label: PropTypes.node,
@@ -31,6 +32,7 @@ const propTypes = {
 };
 
 const InputControl = ({
+  id,
   name,
   label,
   group,
@@ -60,6 +62,8 @@ const InputControl = ({
     }
   }
 
+  id = id || name;
+
   return (
     <div className={classes} style={style} {...otherProps} {...rest} data-testid={testId}>
       <input
@@ -67,11 +71,11 @@ const InputControl = ({
         type={type}
         name={group || name}
         data-testid={`${name}-input`}
-        id={name}
+        id={id}
         {...inputProps}
         checked={value} // has to come after spreading input props to support indeterminate
       />
-      <label className="Checkbox-label" htmlFor={name} {...labelProps}>
+      <label className="Checkbox-label" htmlFor={id} {...labelProps}>
         {label}
       </label>
     </div>

--- a/src/js/components/Radio/Radio.tsx
+++ b/src/js/components/Radio/Radio.tsx
@@ -21,6 +21,7 @@ import * as PropTypes from 'prop-types';
 import { InputControl } from '../InputControl';
 
 const propTypes = {
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
   group: PropTypes.string.isRequired,

--- a/src/js/components/Toggle/Toggle.tsx
+++ b/src/js/components/Toggle/Toggle.tsx
@@ -17,6 +17,7 @@ import * as PropTypes from 'prop-types';
 import { InputControl } from '../InputControl';
 
 const propTypes = {
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   inputProps: PropTypes.object,
   className: PropTypes.string,
@@ -27,10 +28,11 @@ const propTypes = {
 };
 
 const Toggle = (props: PropTypes.InferProps<typeof propTypes>) => {
-  const { name, inputProps, className, mods, style, testId, otherProps } = props;
+  const { id, name, inputProps, className, mods, style, testId, otherProps } = props;
 
   return (
     <InputControl
+      id={id}
       name={name}
       className={className}
       mods={mods}


### PR DESCRIPTION
Currently, Checkbox and Radio components use the name property as the HTML ID attribute. It's common
for those elements to share a name but have unique IDs. This commit adds that functionality.