### PR TITLE
fix: change the package version to match what is on NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.90",
+  "version": "4.0.0-alpha.93",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",


### PR DESCRIPTION
The version on the v4 branch is 90 while the version on NPM is 92. This change puts them back into
sync