### PR TITLE
fix(pill component): add event parameter to onChange handler signature type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamsnap/teamsnap-ui",
-  "version": "4.0.0-alpha.94",
+  "version": "4.0.0-alpha.95",
   "description": "a CSS component library for TeamSnap",
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",

--- a/src/js/components/Pill/Pill.tsx
+++ b/src/js/components/Pill/Pill.tsx
@@ -8,7 +8,7 @@ export interface Props {
   style?: React.CSSProperties;
   mods?: string;
   children: any;
-  onClick?: () => void;
+  onClick?: (e) => void;
   testId?: string;
 }
 


### PR DESCRIPTION
Address issue with TypeScript complaining about passing in the event object when the onChange
handler does not specify any arguments.

RAP-182