### PR TITLE
fix(field component): add 'radio' as an option for the field component's type prop

### DIFF
--- a/src/js/components/Field/Field.tsx
+++ b/src/js/components/Field/Field.tsx
@@ -48,7 +48,7 @@ const inputShape = PropTypes.shape({
 });
 
 const fieldPropTypes = {
-  type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date']).isRequired,
+  type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date', 'radio']).isRequired,
   formFieldProps: PropTypes.oneOfType([checkboxShape, inputShape]),
   id: PropTypes.string,
   name: PropTypes.string.isRequired,

--- a/src/js/components/Field/Field.tsx
+++ b/src/js/components/Field/Field.tsx
@@ -48,7 +48,7 @@ const inputShape = PropTypes.shape({
 });
 
 const fieldPropTypes = {
-  type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date', 'radio']).isRequired,
+  type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date', 'radio', 'number']).isRequired,
   formFieldProps: PropTypes.oneOfType([checkboxShape, inputShape]),
   id: PropTypes.string,
   name: PropTypes.string.isRequired,


### PR DESCRIPTION
Using "radio" as a type option on the Field component was raising warnings in the console. This addresses that issue.