### PR TITLE
fix(checkbox): Update size to use pixel dimensions

### DIFF
--- a/src/css/components/Checkbox.scss
+++ b/src/css/components/Checkbox.scss
@@ -41,6 +41,9 @@ $Checkbox-bg-color: $cu-foreground !default;
     &:before {
       height: $size;
       width: $size;
+      background-size: $size - 4px;
+      background-repeat: no-repeat;
+      background-position: 2px 2px;
     }
   }
 
@@ -173,9 +176,6 @@ $Checkbox-bg-color: $cu-foreground !default;
     top:  0;
     bottom: 0;
     transition: all ease 0.2s;
-    background-size: 90%;
-    background-repeat: no-repeat;
-    background-position: center center;
   }
 }
 
@@ -196,6 +196,7 @@ $Checkbox-bg-color: $cu-foreground !default;
   background-color: color-neutral(1);
   border: solid $border-width-small $cu-divider;
   background-size: 100%;
+  background-position: center;
   transition: none;
 }
 


### PR DESCRIPTION
I recently updated the checkbox design and the percent positioning of the checkbox must not have been hitting a solid pixel value because it was moving around a bit dependent on browser size.

This updates to calculate size and position in pixels based on the overall size of the checkbox so positioning should be consistently correct.

Before:
<img width="437" alt="Screen Shot 2022-02-02 at 12 00 08 PM" src="https://user-images.githubusercontent.com/9888467/152211061-9ab903bf-97b7-4fa2-9030-2bc6660f33c7.png">


After:
<img width="353" alt="Screen Shot 2022-02-02 at 11 54 23 AM" src="https://user-images.githubusercontent.com/9888467/152210913-7a67a8c7-ca9f-473d-80a1-3c3b862851b8.png">
<img width="189" alt="Screen Shot 2022-02-02 at 11 54 31 AM" src="https://user-images.githubusercontent.com/9888467/152210916-ac357313-74c5-4d05-8bbb-dd0e45251eef.png">
<img width="176" alt="Screen Shot 2022-02-02 at 11 54 43 AM" src="https://user-images.githubusercontent.com/9888467/152210919-6e0f1ae2-d6d7-40d4-99e5-e6b1cfe03a82.png">

