### PR TITLE
Move fonts into main file to fix paths issue

### DIFF
--- a/src/css/components/Stepper.scss
+++ b/src/css/components/Stepper.scss
@@ -24,9 +24,11 @@ input[type='number'] {
   padding: 0;
   margin: 0;
   background-color: transparent;
+  color: color-neutral(6);
+
 
   &:hover {
-    color: #1364de !important;
+    color: color-primary(5);
   }
 }
 

--- a/src/css/fonts/index.scss
+++ b/src/css/fonts/index.scss
@@ -1,3 +1,3 @@
 @import "museo";
 @import "open-sans";
-@import "lato";
+// @import "lato";

--- a/src/css/teamsnap-ui.scss
+++ b/src/css/teamsnap-ui.scss
@@ -5,3 +5,82 @@ $responsive: true;
 @import "base/index";
 @import "components/index";
 @import "utils/index";
+
+
+// Import self-hosted fonts here to resolve path issues when consumed as node module by external libraries
+
+/* Webfont: LatoLatin-Regular */
+@font-face {
+    font-family: 'Lato';
+    src: url('../assets/fonts/lato/LatoLatin-Regular.eot'); /* IE9 Compat Modes */
+    src: url('../assets/fonts/lato/LatoLatin-Regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../assets/fonts/lato/LatoLatin-Regular.woff2') format('woff2'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Regular.woff') format('woff'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Regular.ttf') format('truetype');
+    font-style: normal;
+    font-weight: 400;
+    text-rendering: optimizeLegibility;
+}
+
+/* Webfont: LatoLatin-Italic */
+@font-face {
+    font-family: 'Lato';
+    src: url('../assets/fonts/lato/LatoLatin-Italic.eot'); /* IE9 Compat Modes */
+    src: url('../assets/fonts/lato/LatoLatin-Italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../assets/fonts/lato/LatoLatin-Italic.woff2') format('woff2'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Italic.woff') format('woff'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Italic.ttf') format('truetype');
+    font-style: italic;
+    font-weight: 400;
+    text-rendering: optimizeLegibility;
+}
+
+/* Webfont: LatoLatin-Semibold */
+@font-face {
+    font-family: 'Lato';
+    src: url('../assets/fonts/lato/LatoLatin-Semibold.eot'); /* IE9 Compat Modes */
+    src: url('../assets/fonts/lato/LatoLatin-Semibold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../assets/fonts/lato/LatoLatin-Semibold.woff2') format('woff2'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Semibold.woff') format('woff'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Semibold.ttf') format('truetype');
+    font-style: normal;
+    font-weight: 600;
+    text-rendering: optimizeLegibility;
+}
+
+/* Webfont: LatoLatin-SemiboldItalic */
+@font-face {
+    font-family: 'Lato';
+    src: url('../assets/fonts/lato/LatoLatin-SemiboldItalic.eot'); /* IE9 Compat Modes */
+    src: url('../assets/fonts/lato/LatoLatin-SemiboldItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../assets/fonts/lato/LatoLatin-SemiboldItalic.woff2') format('woff2'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-SemiboldItalic.woff') format('woff'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-SemiboldItalic.ttf') format('truetype');
+    font-style: italic;
+    font-weight: 600;
+    text-rendering: optimizeLegibility;
+}
+
+/* Webfont: LatoLatin-Bold */@font-face {
+    font-family: 'Lato';
+    src: url('../assets/fonts/lato/LatoLatin-Bold.eot'); /* IE9 Compat Modes */
+    src: url('../assets/fonts/lato/LatoLatin-Bold.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../assets/fonts/lato/LatoLatin-Bold.woff2') format('woff2'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Bold.woff') format('woff'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-Bold.ttf') format('truetype');
+    font-style: normal;
+    font-weight: 700;
+    text-rendering: optimizeLegibility;
+}
+
+/* Webfont: LatoLatin-BoldItalic */@font-face {
+    font-family: 'Lato';
+    src: url('../assets/fonts/lato/LatoLatin-BoldItalic.eot'); /* IE9 Compat Modes */
+    src: url('../assets/fonts/lato/LatoLatin-BoldItalic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
+         url('../assets/fonts/lato/LatoLatin-BoldItalic.woff2') format('woff2'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-BoldItalic.woff') format('woff'), /* Modern Browsers */
+         url('../assets/fonts/lato/LatoLatin-BoldItalic.ttf') format('truetype');
+    font-style: italic;
+    font-weight: 700;
+    text-rendering: optimizeLegibility;
+}

--- a/src/js/components/Popup/PopupTooltip.tsx
+++ b/src/js/components/Popup/PopupTooltip.tsx
@@ -5,7 +5,7 @@ const propTypes = {
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   testId: PropTypes.string,
   ariaDescribeBy: PropTypes.string,
-  children: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 type Props = PropTypes.InferProps<typeof propTypes>;


### PR DESCRIPTION
This is not ideal, but it was the only way I was able to get the paths working. Relative paths are modified in the node module but not in the local instance, breaking either storybook or the referencing project. This skirts the issue by not nesting the font reference so the relative path stays the same. I'm sure there is a way to fix this with settings in the sass process, but I didn't have the time to go there today.

FYI I did figure out that `yalc` works like a charm for linking TS-UI into teamsnap-spas, so I was able to test solutions in Storybook and Registration Frontend at the same time.