### PR TITLE
feat(component): adding size attribute

### DIFF
--- a/src/js/components/Button/Button.stories.tsx
+++ b/src/js/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { text, boolean } from '@storybook/addon-knobs';
 import Button from './Button';
 import { ScreenReader } from '../ScreenReader';
+import { Loader } from '../Loader';
 
 export default {
   title: 'Components/Forms/Button',
@@ -108,6 +109,15 @@ export const WithIcon = () => (
       <ScreenReader>
         Next
       </ScreenReader>
+    </Button>
+  </div>
+);
+
+export const WithLoader = () => (
+  <div>
+    <Button mods="u-spaceRightSm" isDisabled>
+      <Loader type="spin" size={{ height: 10, width: 10 }} />
+      &nbsp;Processing
     </Button>
   </div>
 );

--- a/src/js/components/Loader/Loader.stories.tsx
+++ b/src/js/components/Loader/Loader.stories.tsx
@@ -5,11 +5,22 @@ export default {
   title: 'Components/Feedback/Loader',
 };
 
+const size = {
+  height: 40,
+  width: 40
+}
+
 export const Default = () => <Loader type="spin" />;
+
+export const SpinWithSize = () => <Loader type="spin" size={ size } />;
 
 export const Pulse = () => <Loader type="pulse" />;
 
+export const PulseWithSize = () => <Loader type="pulse" size={ size } />;
+
 export const Jello = () => <Loader type="jello" />;
+
+export const JelloWithSize = () => <Loader type="jello" size={ size} />;
 
 export const LoaderWithText = () => <Loader type="spin" text="Loading" />;
 

--- a/src/js/components/Loader/Loader.tsx
+++ b/src/js/components/Loader/Loader.tsx
@@ -23,37 +23,74 @@ const propTypes = {
   style: PropTypes.object,
   testId: PropTypes.string,
   otherProps: PropTypes.object,
+  size: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number,
+  }),
 };
 
-const Loader = (props: PropTypes.InferProps<typeof propTypes>) => {
-  const renderSpinAnimation = () => <span className="SpinAnimation" />;
+const Loader = ({
+  type,
+  text,
+  message,
+  className,
+  mods,
+  style,
+  testId,
+  otherProps,
+  size
+}: PropTypes.InferProps<typeof propTypes>) => {
+  const renderSpinAnimation = () => <span style={{ ...size }} className="SpinAnimation" />;
 
   const renderPulseAnimation = () => (
     <span className="PulseAnimation">
-      <span className="PulseAnimation-dot" />
-      <span className="PulseAnimation-dot" />
-      <span className="PulseAnimation-dot" />
+      <span style={{ ...size }} className="PulseAnimation-dot" />
+      <span style={{ ...size }} className="PulseAnimation-dot" />
+      <span style={{ ...size }} className="PulseAnimation-dot" />
     </span>
   );
 
-  const renderJelloAnimation = () => (
-    <span className="JelloAnimation">
-      <span className="JelloAnimation-shadow" />
-      <span className="JelloAnimation-box" />
-    </span>
-  );
+  const renderJelloAnimation = () => {
+    // These numbers are base on the JelloAnimation container size of 40 as well as the
+    // ratio between the container size and the default animation size of 32 which is 0.2
+    let width = 32;
+    let offset = 4;
+    const containerRatio = 0.2;
 
-  const renderAnimation = (type) => {
-    if (type === 'jello') {
+    if (size) {
+      offset = Math.ceil(size?.width / 8);
+      width = size?.width;
+    }
+
+    const containerSize = (containerRatio * width) + width;
+
+    return (
+      <span
+        className="JelloAnimation"
+        style={{ width: containerSize, height: containerSize }}
+      >
+        <span
+          style={{
+            width,
+            height: offset,
+            bottom: -offset,
+          }}
+          className="JelloAnimation-shadow"
+        />
+        <span style={{ ...size }} className="JelloAnimation-box" />
+      </span>
+    );
+  }
+
+  const renderAnimation = (animation) => {
+    if (animation === 'jello') {
       return renderJelloAnimation();
     }
-    if (type === 'pulse') {
+    if (animation === 'pulse') {
       return renderPulseAnimation();
     }
     return renderSpinAnimation();
   };
-
-  const { type, text, message, className, mods, style, testId, otherProps } = props;
 
   if (!text && !message) {
     return renderAnimation(type);


### PR DESCRIPTION
Adding custom size attribute to allow better composition. As you can see in the screenshot below, we can not manipulate the size of the animations

<img width="1595" alt="Screen Shot 2022-05-24 at 4 16 31 PM" src="https://user-images.githubusercontent.com/1371105/170124344-0789dc45-c26b-40f9-9461-296129634f73.png">

