### PR TITLE
feat(component): modified Popup Action to have customized button

### DIFF
--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -117,6 +117,25 @@ export const PopupActionsOverlay = () => (
   </div>
 );
 
+export const PopupActionsCustomizedOrigin = () => (
+  <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
+    <div>
+      <PopupAction
+        text='TS'
+        actions={actions}
+        direction={['down', 'rightHang']}
+        showOnHover={false}
+        popupStyle={{ width: '150px' }}
+        originButtonStyle={{
+          height: '40px',
+          width: '40px',
+          borderRadius: '20px',
+        }}
+      />
+    </div>
+  </div>
+);
+
 export const PopupConfirm = () => {
   const popupText = <h4>Do you really want to hurt me? Do you really want to make me cry?</h4>;
   const onAccept = () => {

--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -126,7 +126,7 @@ export const PopupActionsCustomizedOrigin = () => (
         direction={['down', 'rightHang']}
         showOnHover={false}
         popupStyle={{ width: '150px' }}
-        originButtonStyle={{
+        buttonStyle={{
           height: '40px',
           width: '40px',
           borderRadius: '20px',

--- a/src/js/components/Popup/Popup.stories.tsx
+++ b/src/js/components/Popup/Popup.stories.tsx
@@ -121,7 +121,7 @@ export const PopupActionsCustomizedOrigin = () => (
   <div style={{ display: 'flex', justifyContent: 'center', minHeight: '100px' }}>
     <div>
       <PopupAction
-        text='TS'
+        text={<img src="https://res-4.cloudinary.com/crunchbase-production/image/upload/c_lpad,f_auto,q_auto:eco/v1398359819/ebi2jfu0t7embtj1i35w.png"></img>}
         actions={actions}
         direction={['down', 'rightHang']}
         showOnHover={false}

--- a/src/js/components/Popup/PopupAction.tsx
+++ b/src/js/components/Popup/PopupAction.tsx
@@ -27,7 +27,7 @@ const propTypes = {
   showOnHover: PropTypes.bool,
   testId: PropTypes.string,
   selectorRef: PropTypes.any,
-  originButtonStyle: PropTypes.object
+  buttonStyle: PropTypes.object
 };
 
 type Props = PropTypes.InferProps<typeof propTypes>;
@@ -125,7 +125,7 @@ export default class PopUpAction extends React.Component<Props, State> {
   }
 
   render() {
-    const { actions, direction, popupStyle, text, showOnHover, testId, originButtonStyle } = this.props;
+    const { actions, direction, popupStyle, text, showOnHover, testId, buttonStyle } = this.props;
     const { state } = this;
     const { isConfirmOpen, hoverPopupOpen, selectedAction, clickPopupOpen } = state;
     const { callback, confirmationText, requiresConfirmation } = selectedAction;
@@ -149,7 +149,7 @@ export default class PopUpAction extends React.Component<Props, State> {
             type="button"
             className="Button Button--small"
             onClick={this.togglePopup.bind(this)}
-            style={originButtonStyle}
+            style={buttonStyle}
           >
             {text}
           </button>

--- a/src/js/components/Popup/PopupAction.tsx
+++ b/src/js/components/Popup/PopupAction.tsx
@@ -27,6 +27,7 @@ const propTypes = {
   showOnHover: PropTypes.bool,
   testId: PropTypes.string,
   selectorRef: PropTypes.any,
+  originButtonStyle: PropTypes.object
 };
 
 type Props = PropTypes.InferProps<typeof propTypes>;
@@ -124,7 +125,7 @@ export default class PopUpAction extends React.Component<Props, State> {
   }
 
   render() {
-    const { actions, direction, popupStyle, text, showOnHover, testId } = this.props;
+    const { actions, direction, popupStyle, text, showOnHover, testId, originButtonStyle } = this.props;
     const { state } = this;
     const { isConfirmOpen, hoverPopupOpen, selectedAction, clickPopupOpen } = state;
     const { callback, confirmationText, requiresConfirmation } = selectedAction;
@@ -148,6 +149,7 @@ export default class PopUpAction extends React.Component<Props, State> {
             type="button"
             className="Button Button--small"
             onClick={this.togglePopup.bind(this)}
+            style={originButtonStyle}
           >
             {text}
           </button>


### PR DESCRIPTION
Modified Popup Actions component to handle origin button styles customization.

<img width="839" alt="image" src="https://user-images.githubusercontent.com/85572162/194898417-e2e30d6e-0114-429b-beca-330e9bcbd928.png">
<img width="850" alt="image" src="https://user-images.githubusercontent.com/85572162/194898456-6e685b03-5657-40c1-ba51-544783997de3.png">
<img width="854" alt="image" src="https://user-images.githubusercontent.com/85572162/194901044-6b40eb6c-982b-4891-a64d-dc6fd107672c.png">
<img width="835" alt="image" src="https://user-images.githubusercontent.com/85572162/194901099-9dca6bd1-f6c5-4c3d-80b3-8d139cbd9068.png">

