### PR TITLE
RAP-1187: Debug TeamSnap UI Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: 16
       - name: Install dependencies
         run: yarn
       - name: Release


### PR DESCRIPTION
- The node version number of the last successful build is different from the most current broken build. Changing the version number to point to 16 specifically. 