### PR TITLE
feat(tabs.tsx): add activeIndex prop to Tabs component

### DIFF
--- a/src/js/components/Tabs/Tabs.tsx
+++ b/src/js/components/Tabs/Tabs.tsx
@@ -32,6 +32,7 @@ interface Tab {
 }
 
 export interface Props {
+  activeIndex?: number;
   mods?: string;
   tabs: Tab[];
   testId?: string;
@@ -41,10 +42,10 @@ export interface Props {
 
 const Tabs = React.forwardRef(
   (
-    { mods, tabs, testId, renderOnload, disableFirstAfterLoad }: Props,
+    { activeIndex, mods, tabs, testId, renderOnload, disableFirstAfterLoad }: Props,
     ref: MutableRefObject<{ setActiveTabIndex: (index: number) => void }>
   ) => {
-    const [activeTabIndex, setActiveTabIndex] = React.useState(0);
+    const [activeTabIndex, setActiveTabIndex] = React.useState(activeIndex ?? 0);
     const [initialized, setInitialized] = React.useState(false);
     const boolMods = !!mods;
 


### PR DESCRIPTION
Allow Tabs component to accept activeIndex prop to determine initial rendering.

re https://teamsnap.atlassian.net/browse/RAP-1216