### PR TITLE
fix: downgrade typescript to fix dynamic import issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@types/react": "17.0.2",
     "browserslist": "^4.16.5",
     "glob-parent": "^5.1.2",
+    "typescript": "4.8.4",
     "trim": "^0.0.3"
   },
   "config": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19925,23 +19925,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.0.3, typescript@npm:^4.6.2, typescript@npm:^4.6.4":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:4.8.4":
+  version: 4.8.4
+  resolution: "typescript@npm:4.8.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.0.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.4#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+"typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>":
+  version: 4.8.4
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=1a91c8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: c981e82b77a5acdcc4e69af9c56cdecf5b934a87a08e7b52120596701e389a878b8e3f860e73ffb287bf649cc47a8c741262ce058148f71de4cdd88bb9c75153
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When I updated several packages, I also update TypeScript by a few minor versions - it is rare, but this caught a bug with a new TypeScript version. [TypeScript 4.9](https://github.com/microsoft/TypeScript/releases/tag/v4.9.3) introduced a change that altered how dynamic imports worked (see attached screenshot for the issue in the changelog for TS 4.9). [This change](https://github.com/microsoft/TypeScript/pull/49663), cause dynamic imports to be transpiled from:

```js
Promise.resolve().then(function () { return require(x); })
```

to

```js
(_a = x, Promise.resolve().then(() => require(_a))
```

When transpiling to a CommonJS module format, which we are doing. This is a problem, because while Webpack tree-shaking can determine asset relevance in the first example, it cannot in the second.

This PR forces the TS resolution to stop at 4.8.4, which removes this change and maintains the prior transpilation of the `Icon` component.

![Screen Shot 2023-03-21 at 12 12 04 PM](https://user-images.githubusercontent.com/2548998/226673946-0ef0bf58-230d-4712-b89a-0d1fcfa7fc1a.png)