### PR TITLE
feat: [PLAT-2922] reference GCS instead of rackspace

### DIFF
--- a/src/js/components/Avatar/Avatar.stories.tsx
+++ b/src/js/components/Avatar/Avatar.stories.tsx
@@ -12,7 +12,7 @@ export default {
 stories.add("Default", () => (
   <Avatar
     mods="u-spaceRightSm"
-    src="https://aa5498032991a101442c-34c0f4eec246050dfc1ee92670a7b97d.ssl.cf1.rackcdn.com/logo-icon-dafd29abff7b6ca55ad71c35bd34d679.png"
+    src="https://storage.googleapis.com/ts_assets_prod-classic_assets/logo-icon-dafd29abff7b6ca55ad71c35bd34d679.png"
     size="md"
    />
 ));


### PR DESCRIPTION
Assets have moved to GCS, updating reference for logo
