### PR TITLE
refactor(component): adding onChange event to prevent typescript errors

### DIFF
--- a/src/js/components/Field/Field.tsx
+++ b/src/js/components/Field/Field.tsx
@@ -33,6 +33,7 @@ const checkboxShape = PropTypes.shape({
   text: PropTypes.string,
   checked: CheckboxState.PropType,
   onClick: PropTypes.func,
+  onChange: PropTypes.func,
   isIndeterminate: PropTypes.bool,
 });
 
@@ -95,6 +96,7 @@ const Field = ({
           text,
           checked,
           onClick,
+          onChange,
           leftIcon,
           rightIcon,
           placeholder,
@@ -114,6 +116,7 @@ const Field = ({
                 inputProps={{
                   checked,
                   onClick,
+                  onChange,
                   disabled: isDisabled,
                 }}
                 label={text}
@@ -128,6 +131,7 @@ const Field = ({
                 inputProps={{
                   checked,
                   onClick,
+                  onChange,
                   disabled: isDisabled,
                 }}
                 label={text}

--- a/src/js/components/ToggleCheckboxList/ToggleCheckboxList.tsx
+++ b/src/js/components/ToggleCheckboxList/ToggleCheckboxList.tsx
@@ -187,6 +187,7 @@ const ToggleCheckboxList: React.FunctionComponent<Props> = ({
               onClick: () => {
                 onRowClick(heading, subheading, uniqueId, parentIdx);
               },
+              onChange: () => {}
             }}
           />
         </PanelRow>
@@ -242,6 +243,7 @@ const ToggleCheckboxList: React.FunctionComponent<Props> = ({
                 formFieldProps={{
                   checked: headerStatus[headerName] && headerStatus[headerName].status,
                   onClick: () => toggleSubheadingRows(heading, subheading, idx),
+                  onChange: () => {}
                 }}
               />
             </div>


### PR DESCRIPTION
This change is being made to remove typescript warnings/ errors that are showing up during unit test execution

<img width="1268" alt="Screen Shot 2023-08-14 at 2 25 44 PM" src="https://github.com/teamsnap/teamsnap-ui/assets/1371105/7d7b16ba-5f7c-4d1e-a0a3-2ec8da458975">

This will lead to a 33% reduction in error messages from roughly 7400 lines to 4900
