### PR TITLE
feat(component): adding text option for Field component

### DIFF
--- a/src/js/components/Field/Field.tsx
+++ b/src/js/components/Field/Field.tsx
@@ -49,7 +49,7 @@ const inputShape = PropTypes.shape({
 });
 
 const fieldPropTypes = {
-  type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date', 'radio', 'number']).isRequired,
+  type: PropTypes.oneOf(['toggle', 'select', 'input', 'checkbox', 'date', 'radio', 'number', 'text']).isRequired,
   formFieldProps: PropTypes.oneOfType([checkboxShape, inputShape]),
   id: PropTypes.string,
   name: PropTypes.string.isRequired,


### PR DESCRIPTION
Adding `text` type to the `type` attribute in order to avoid console errors for when trying to use the type text which is a valid input option

<img width="1373" alt="Screen Shot 2023-08-17 at 11 27 00 AM" src="https://github.com/teamsnap/teamsnap-ui/assets/1371105/00d8bdd1-b396-4d47-bbf9-007707a49b8a">
