### PR TITLE
feat(component): adding OnHoverText option

### DIFF
--- a/src/js/components/ComboBox/Combobox.tsx
+++ b/src/js/components/ComboBox/Combobox.tsx
@@ -55,6 +55,7 @@ const propTypes = {
   doneButtonText: PropTypes.string,
   showSelectAll: PropTypes.bool,
   searchPlaceholder: PropTypes.string,
+  onHoverText: PropTypes.string,
 };
 interface Filter {
   value: string;
@@ -100,6 +101,7 @@ const ComboBox = ({
   doneButtonText,
   showSelectAll,
   searchPlaceholder,
+  onHoverText,
 }: Props) => {
   const [initialized, setInitialized] = React.useState(false);
   const [flyoutVisible, toggleFlyout] = React.useState(false);
@@ -255,7 +257,7 @@ const ComboBox = ({
         id={name}
         data-testid="comboboxButton"
         disabled={disabled}
-        title={comboLabel ?? ''}
+        title={onHoverText && disabled ? onHoverText : comboLabel ?? ''}
         onClick={() => toggleFlyout(!flyoutVisible)}
       >
         {comboLabel ?? buttonLabel}
@@ -357,6 +359,7 @@ ComboBox.defaultProps = {
   doneButtonText: 'Done',
   showSelectAll: false,
   searchPlaceholder: null,
+  onHoverText: '',
 };
 
 export default ComboBox;


### PR DESCRIPTION
Adding on hover state text so we can hint that a `ComboBox` is reliant on another As per [B2B-1625](https://teamsnap.atlassian.net/browse/B2B-1625) 

<img width="553" alt="Screen Shot 2023-08-21 at 2 11 49 PM" src="https://github.com/teamsnap/teamsnap-ui/assets/1371105/f3980f5c-13ee-4236-82da-29e6b384c80c">


[B2B-1625]: https://teamsnap.atlassian.net/browse/B2B-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ