### PR TITLE
chore: [PLAT-4443] move dependabot to Sundays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
+---
 version: 2
 updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-    time: "12:00"
+    interval: weekly
+    day: sunday
   pull-request-branch-name:
     separator: "-"
   open-pull-requests-limit: 15


### PR DESCRIPTION
In an effort to cut down on the noise in developer feeds,
this PR will move dependabot to run on Sundays only.
