### PR TITLE
build: disable post install scripts of deps by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 yarnPath: ".yarn/releases/yarn-berry.cjs"
 nodeLinker: node-modules
 enableGlobalCache: true
+
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -102,5 +102,13 @@
     "css-what": "^5.0.1",
     "glob-parent": "^5.1.2",
     "trim": "^0.0.3"
+  },
+  "dependenciesMeta": {
+    "core-js": {
+      "built": true
+    },
+    "core-js-pure": {
+      "built": true
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3414,7 +3414,7 @@ __metadata:
     gulp-util: ^3.0.8
     html-webpack-plugin: ^5.3.1
     lodash: ^4.17.15
-    object-path: ">=0.11.5"
+    object-path: ">=0.11.8"
     prop-types: ^15.6.1
     react: ^17.0.1
     react-docgen-typescript-loader: ^3.1.0
@@ -3428,6 +3428,11 @@ __metadata:
     webpack: 4
   peerDependencies:
     react: ^17.0.1
+  dependenciesMeta:
+    core-js:
+      built: true
+    core-js-pure:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -12455,10 +12460,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-path@npm:>=0.11.5":
-  version: 0.11.5
-  resolution: "object-path@npm:0.11.5"
-  checksum: a2be57f65eb247161763280e857ddbafcfbb41ad7cfcfb0a78aca2e8adb990a7b5afe6b182c20baf0e218e541ec75c1807fd04d50e3049920c2ec65e6eb9c900
+"object-path@npm:>=0.11.8":
+  version: 0.11.8
+  resolution: "object-path@npm:0.11.8"
+  checksum: daf845abe3054b38a2ecd40ada58ffca30b4704d102f0426aa87afa6a02313226d87c9db6a0e9297aeb387047b567dbc790fb0599ab1a53e630298f7f79687db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Disable all dependency postinstall scripts by default (`enableScripts: false` in `.yarnrc.yml`)
- Allowlist dependencies that need postinstall scripts via `dependenciesMeta` in `package.json`

Affected dependencies: `core-js`, `core-js-pure`

## Test plan

- [ ] Verify `yarn install` completes successfully
- [ ] Verify the application builds and starts correctly
- [ ] Verify tests pass