### PR TITLE
chore(codeowners): make Platform owner of infra files [PLAT-7118]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
 * @teamsnap/orgs-web-frontend
+.teamsnap/** @teamsnap/platform @teamsnap/orgs-web-frontend
+.github/** @teamsnap/platform @teamsnap/quality @teamsnap/orgs-web-frontend
+CODEOWNERS @teamsnap/platform @teamsnap/orgs-web-frontend


### PR DESCRIPTION
## Summary

Implements [PLAT-7118](https://teamsnap.atlassian.net/browse/PLAT-7118) for this repo. Opened as a **draft**.

## Transformation
- Add `@teamsnap/platform` + `@teamsnap/quality` as owners of `.github/**`.
- Add `@teamsnap/platform` as co-owner of `infra/**` and `.teamsnap/**` (where present; existing owners kept).
- Add the `CODEOWNERS` self-ownership line (`@teamsnap/platform` + primary team).
- `*` catch-all owner unchanged. File kept at repo root.

## Access validity
Push access for the new owners is granted in companion PR [terraform-deployments#2479](https://github.com/teamsnap/terraform-deployments/pull/2479). Owners are honored by GitHub once that PR merges & applies. All owners verified with the update-codeowners skill verifier.

Generated with Claude Code

[PLAT-7118]: https://teamsnap.atlassian.net/browse/PLAT-7118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ